### PR TITLE
JS memory expression error

### DIFF
--- a/wdl2cwl/main.py
+++ b/wdl2cwl/main.py
@@ -56,11 +56,11 @@ def get_ram_min_js(ram_min: str) -> str:
         + 'else if(unit==="GiB") memory = value*1024;\n'
         + 'else if(unit==="TiB") memory = value*1024*1024;\n'
         + 'else if(unit==="B") memory = value/(1024*1024);\n'
-        + 'else if(unit==="KB" || unit==="K") memory = (value*1000)/(1024**2);\n'
-        + 'else if(unit==="MB" || unit==="M") memory = (value*(1000**2))/(1024**2);\n'
-        + 'else if(unit==="GB" || unit==="G") memory = (value*(1000**3))/(1024**2);\n'
-        + 'else if(unit==="TB" || unit==="T") memory = (value*(1000**4))/(1024**2);\n'
-        + "return memory;\n}"
+        + 'else if(unit==="KB" || unit==="K") memory = (value*1000)/(1024*1024);\n'
+        + 'else if(unit==="MB" || unit==="M") memory = (value*(1000*1000))/(1024*1024);\n'
+        + 'else if(unit==="GB" || unit==="G") memory = (value*(1000*1000*1000))/(1024*1024);\n'
+        + 'else if(unit==="TB" || unit==="T") memory = (value*(1000*1000*1000*1000))/(1024*1024);\n'
+        + "return parseInt(memory);\n}"
     )
 
     return js_str

--- a/wdl2cwl/tests/cwl_files/smoove.cwl
+++ b/wdl2cwl/tests/cwl_files/smoove.cwl
@@ -55,11 +55,11 @@ requirements:
         else if(unit==="GiB") memory = value*1024;
         else if(unit==="TiB") memory = value*1024*1024;
         else if(unit==="B") memory = value/(1024*1024);
-        else if(unit==="KB" || unit==="K") memory = (value*1000)/(1024**2);
-        else if(unit==="MB" || unit==="M") memory = (value*(1000**2))/(1024**2);
-        else if(unit==="GB" || unit==="G") memory = (value*(1000**3))/(1024**2);
-        else if(unit==="TB" || unit==="T") memory = (value*(1000**4))/(1024**2);
-        return memory;
+        else if(unit==="KB" || unit==="K") memory = (value*1000)/(1024*1024);
+        else if(unit==="MB" || unit==="M") memory = (value*(1000*1000))/(1024*1024);
+        else if(unit==="GB" || unit==="G") memory = (value*(1000*1000*1000))/(1024*1024);
+        else if(unit==="TB" || unit==="T") memory = (value*(1000*1000*1000*1000))/(1024*1024);
+        return parseInt(memory);
         }
   - class: ToolTimeLimit
     timelimit: $(inputs.timeMinutes* 60)


### PR DESCRIPTION
When smoove.cwl (https://github.com/common-workflow-lab/wdl-cwl-translator/blob/main/wdl2cwl/tests/cwl_files/smoove.cwl) was run with test inputs, ```Got incorrect return type <class 'float'> from resource expression evaluation of $ ``` error was encountered. Therefore, changed the return type to int.
Handled warning for ```JSHINT: W119: 'Exponentiation operator' is only available in ES7. CWL only supports ES5.1``` by changing exponentiation to multiplication.
