### PR TITLE
Handle optional array inputs

### DIFF
--- a/wdl2cwl/main.py
+++ b/wdl2cwl/main.py
@@ -322,15 +322,12 @@ def get_input(
             )
             input_name = i[1]
 
-            if "?" not in i[0]:
-                inputs.append(
-                    cwl.CommandInputParameter(
-                        id=input_name,
-                        type=[
-                            cwl.CommandInputArraySchema(items=input_type, type="array")
-                        ],
-                    )
+            inputs.append(
+                cwl.CommandInputParameter(
+                    id=input_name,
+                    type=[cwl.CommandInputArraySchema(items=input_type, type="array")],
                 )
+            )
 
         else:
             input_type = (

--- a/wdl2cwl/main.py
+++ b/wdl2cwl/main.py
@@ -183,9 +183,10 @@ def get_command(
                 if input_name in input_names:
                     append_str = (
                         '${\nvar text = "";\n'
-                        + 'for(var i=0;i<inputs["'
+                        + 'var arr_length = inputs["'
                         + input_name
-                        + '"].length;i++) \n'
+                        + '"].length;\n'
+                        + "for(var i=0;i<arr_length-1;i++) \n"
                         + '  text+= inputs["'
                         + input_name
                         + '"][i]'
@@ -193,6 +194,11 @@ def get_command(
                         + '+"'
                         + separator
                         + '";\n'
+                        + 'text+= inputs["'
+                        + input_name
+                        + '"][arr_length-1]'
+                        + temp_append_str
+                        + ";\n"
                         + "return text;\n"
                         + "}"
                     )

--- a/wdl2cwl/main.py
+++ b/wdl2cwl/main.py
@@ -173,6 +173,12 @@ def get_command(
                 split_str = sub_str.split(sub_str[4])
                 separator = split_str[1]
                 input_name = split_str[2]
+                index = input_names.index(input_name)
+                data_type = input_types[index]
+
+                temp_append_str = ""
+                if "Array[File]" in data_type:
+                    temp_append_str = ".path"
 
                 if input_name in input_names:
                     append_str = (
@@ -182,7 +188,9 @@ def get_command(
                         + '"].length;i++) \n'
                         + '  text+= inputs["'
                         + input_name
-                        + '"][i]+"'
+                        + '"][i]'
+                        + temp_append_str
+                        + '+"'
                         + separator
                         + '";\n'
                         + "return text;\n"

--- a/wdl2cwl/main.py
+++ b/wdl2cwl/main.py
@@ -147,11 +147,18 @@ def get_command(
 
                 elif "defined(" in input_name:
                     sub_str = input_name[input_name.find("(") + 1 : -1]
+                    index = input_names.index(sub_str)
+                    data_type = input_types[index]
+                    check_str = ""
+                    if "Array" in data_type:
+                        check_str=".length === 0 "
+                    else:
+                        check_str=' === "" '
                     append_str = (
                         '$(inputs["'
                         + sub_str
-                        + '"] === '
-                        + '"" ? '
+                        + '"]' 
+                        + check_str +'? '
                         + '"'
                         + false_value
                         + '"'
@@ -338,7 +345,7 @@ def get_input(
                         type=[
                             cwl.CommandInputArraySchema(items=input_type, type="array")
                         ],
-                        default="",
+                        default=[],
                     )
                 )
 

--- a/wdl2cwl/main.py
+++ b/wdl2cwl/main.py
@@ -151,14 +151,15 @@ def get_command(
                     data_type = input_types[index]
                     check_str = ""
                     if "Array" in data_type:
-                        check_str=".length === 0 "
+                        check_str = ".length === 0 "
                     else:
-                        check_str=' === "" '
+                        check_str = ' === "" '
                     append_str = (
                         '$(inputs["'
                         + sub_str
-                        + '"]' 
-                        + check_str +'? '
+                        + '"]'
+                        + check_str
+                        + "? "
                         + '"'
                         + false_value
                         + '"'

--- a/wdl2cwl/main.py
+++ b/wdl2cwl/main.py
@@ -322,12 +322,25 @@ def get_input(
             )
             input_name = i[1]
 
-            inputs.append(
-                cwl.CommandInputParameter(
-                    id=input_name,
-                    type=[cwl.CommandInputArraySchema(items=input_type, type="array")],
+            if "?" not in i[0]:
+                inputs.append(
+                    cwl.CommandInputParameter(
+                        id=input_name,
+                        type=[
+                            cwl.CommandInputArraySchema(items=input_type, type="array")
+                        ],
+                    )
                 )
-            )
+            else:
+                inputs.append(
+                    cwl.CommandInputParameter(
+                        id=input_name,
+                        type=[
+                            cwl.CommandInputArraySchema(items=input_type, type="array")
+                        ],
+                        default="",
+                    )
+                )
 
         else:
             input_type = (

--- a/wdl2cwl/tests/cwl_files/gatk_1.cwl
+++ b/wdl2cwl/tests/cwl_files/gatk_1.cwl
@@ -17,55 +17,6 @@ inputs:
     type: File
   - id: referenceFastaDict
     type: File
-  - id: intervalList
-    default: []
-    type:
-      - items:
-          - File
-          - 'null'
-        type: array
-  - id: excludeIntervalList
-    default: []
-    type:
-      - items:
-          - File
-          - 'null'
-        type: array
-  - id: contamination
-    default: ''
-    type:
-      - float
-      - 'null'
-  - id: dbsnpVCF
-    default: ''
-    type:
-      - File
-      - 'null'
-  - id: dbsnpVCFIndex
-    default: ''
-    type:
-      - File
-      - 'null'
-  - id: pedigree
-    default: ''
-    type:
-      - File
-      - 'null'
-  - id: ploidy
-    default: ''
-    type:
-      - int
-      - 'null'
-  - id: outputMode
-    default: ''
-    type:
-      - string
-      - 'null'
-  - id: standardMinConfidenceThresholdForCalling
-    default: ''
-    type:
-      - float
-      - 'null'
   - id: gvcf
     default: false
     type: boolean
@@ -96,13 +47,13 @@ requirements:
   - class: InitialWorkDirRequirement
     listing:
       - entryname: example.sh
-        entry: |4
+        entry: |4+
 
             set -e
             mkdir -p "\$(dirname $(inputs.outputPath))"
             gatk --java-options '-Xmx$(inputs.javaXmxMb)M -XX:ParallelGCThreads=1' \
             HaplotypeCaller \
-            -R $(inputs.referenceFasta.path) \
+            -R wd2/$(inputs.basename(referenceFasta)) \
             -O $(inputs.outputPath) \
             -I ${
             var text = "";
@@ -110,26 +61,8 @@ requirements:
               text+= inputs["inputBams"][i].path+" -I ";
             return text;
             } \
-            --sample-ploidy $(inputs.ploidy) \
-            $(inputs["intervalList"].length === 0 ? "": "-L") ${
-            var text = "";
-            for(var i=0;i<inputs["intervalList"].length;i++) 
-              text+= inputs["intervalList"][i].path+" -L ";
-            return text;
-            } \
-            $(inputs["excludeIntervalList"].length === 0 ? "": "-XL") ${
-            var text = "";
-            for(var i=0;i<inputs["excludeIntervalList"].length;i++) 
-              text+= inputs["excludeIntervalList"][i].path+" -XL ";
-            return text;
-            } \
-            -D $(inputs.dbsnpVCF) \
-            --pedigree $(inputs.pedigree) \
-            --contamination-fraction-per-sample-file $(inputs.contamination) \
-            --output-mode $(inputs.outputMode) \
-            --emit-ref-confidence $(inputs.emitRefConfidence) \
             $(inputs["dontUseSoftClippedBases"] ? "--dont-use-soft-clipped-bases" : "") \
-            --standard-min-confidence-threshold-for-calling $(inputs.standardMinConfidenceThresholdForCalling)
+
   - class: InlineJavascriptRequirement
   - class: ToolTimeLimit
     timelimit: $(inputs.timeMinutes* 60)

--- a/wdl2cwl/tests/cwl_files/gatk_1.cwl
+++ b/wdl2cwl/tests/cwl_files/gatk_1.cwl
@@ -17,6 +17,20 @@ inputs:
     type: File
   - id: referenceFastaDict
     type: File
+  - id: intervalList
+    default: []
+    type:
+      - items:
+          - File
+          - 'null'
+        type: array
+  - id: excludeIntervalList
+    default: []
+    type:
+      - items:
+          - File
+          - 'null'
+        type: array
   - id: gvcf
     default: false
     type: boolean
@@ -51,14 +65,32 @@ requirements:
 
             set -e
             mkdir -p "\$(dirname $(inputs.outputPath))"
+            mkdir wd
+            for FILE in $(inputs.sep(" ",inputBams)); do ln -s $FILE wd/\$(inputBams $FILE) ; done
+            for FILE in $(inputs.sep(" ",inputBamsIndex)); do ln -s $FILE wd/\$(inputBamsIndex $FILE) ; done
+            mkdir wd2
+            ln -s $(inputs.referenceFasta.path) wd2/$(inputs.basename(referenceFasta))
+            ln -s $(inputs.referenceFastaDict.path) wd2/$(inputs.basename(referenceFastaDict))
+            ln -s $(inputs.referenceFastaFai) wd2/$(inputs.basename(referenceFastaFai))
             gatk --java-options '-Xmx$(inputs.javaXmxMb)M -XX:ParallelGCThreads=1' \
             HaplotypeCaller \
             -R wd2/$(inputs.basename(referenceFasta)) \
             -O $(inputs.outputPath) \
-            -I ${
+            (for FILE in $(inputs.sep(" ",inputBams)); do echo -- "-I wd/"\$(basename $FILE); done)
+            $(inputs["intervalList"].length === 0 ? "": "-L") ${
             var text = "";
-            for(var i=0;i<inputs["inputBams"].length;i++) 
-              text+= inputs["inputBams"][i].path+" -I ";
+            var arr_length = inputs["intervalList"].length;
+            for(var i=0;i<arr_length-1;i++) 
+              text+= inputs["intervalList"][i].path+" -L ";
+            text+= inputs["intervalList"][arr_length-1].path;
+            return text;
+            } \
+            $(inputs["excludeIntervalList"].length === 0 ? "": "-XL") ${
+            var text = "";
+            var arr_length = inputs["excludeIntervalList"].length;
+            for(var i=0;i<arr_length-1;i++) 
+              text+= inputs["excludeIntervalList"][i].path+" -XL ";
+            text+= inputs["excludeIntervalList"][arr_length-1].path;
             return text;
             } \
             $(inputs["dontUseSoftClippedBases"] ? "--dont-use-soft-clipped-bases" : "") \

--- a/wdl2cwl/tests/cwl_files/gatk_1.cwl
+++ b/wdl2cwl/tests/cwl_files/gatk_1.cwl
@@ -18,12 +18,14 @@ inputs:
   - id: referenceFastaDict
     type: File
   - id: intervalList
+    default: ''
     type:
       - items:
           - File
           - 'null'
         type: array
   - id: excludeIntervalList
+    default: ''
     type:
       - items:
           - File

--- a/wdl2cwl/tests/cwl_files/gatk_1.cwl
+++ b/wdl2cwl/tests/cwl_files/gatk_1.cwl
@@ -107,20 +107,20 @@ requirements:
             -I ${
             var text = "";
             for(var i=0;i<inputs["inputBams"].length;i++) 
-              text+= inputs["inputBams"][i]+" -I ";
+              text+= inputs["inputBams"][i].path+" -I ";
             return text;
             } \
             --sample-ploidy $(inputs.ploidy) \
             $(inputs["intervalList"].length === 0 ? "": "-L") ${
             var text = "";
             for(var i=0;i<inputs["intervalList"].length;i++) 
-              text+= inputs["intervalList"][i]+" -L ";
+              text+= inputs["intervalList"][i].path+" -L ";
             return text;
             } \
             $(inputs["excludeIntervalList"].length === 0 ? "": "-XL") ${
             var text = "";
             for(var i=0;i<inputs["excludeIntervalList"].length;i++) 
-              text+= inputs["excludeIntervalList"][i]+" -XL ";
+              text+= inputs["excludeIntervalList"][i].path+" -XL ";
             return text;
             } \
             -D $(inputs.dbsnpVCF) \

--- a/wdl2cwl/tests/cwl_files/gatk_1.cwl
+++ b/wdl2cwl/tests/cwl_files/gatk_1.cwl
@@ -18,14 +18,14 @@ inputs:
   - id: referenceFastaDict
     type: File
   - id: intervalList
-    default: ''
+    default: []
     type:
       - items:
           - File
           - 'null'
         type: array
   - id: excludeIntervalList
-    default: ''
+    default: []
     type:
       - items:
           - File
@@ -111,13 +111,13 @@ requirements:
             return text;
             } \
             --sample-ploidy $(inputs.ploidy) \
-            $(inputs["intervalList"] === "" ? "": "-L") ${
+            $(inputs["intervalList"].length === 0 ? "": "-L") ${
             var text = "";
             for(var i=0;i<inputs["intervalList"].length;i++) 
               text+= inputs["intervalList"][i]+" -L ";
             return text;
             } \
-            $(inputs["excludeIntervalList"] === "" ? "": "-XL") ${
+            $(inputs["excludeIntervalList"].length === 0 ? "": "-XL") ${
             var text = "";
             for(var i=0;i<inputs["excludeIntervalList"].length;i++) 
               text+= inputs["excludeIntervalList"][i]+" -XL ";

--- a/wdl2cwl/tests/cwl_files/gatk_1.cwl
+++ b/wdl2cwl/tests/cwl_files/gatk_1.cwl
@@ -1,0 +1,137 @@
+class: CommandLineTool
+id: HaplotypeCaller
+inputs:
+  - id: inputBams
+    type:
+      - items: File
+        type: array
+  - id: inputBamsIndex
+    type:
+      - items: File
+        type: array
+  - id: outputPath
+    type: string
+  - id: referenceFasta
+    type: File
+  - id: referenceFastaIndex
+    type: File
+  - id: referenceFastaDict
+    type: File
+  - id: intervalList
+    type:
+      - items:
+          - File
+          - 'null'
+        type: array
+  - id: excludeIntervalList
+    type:
+      - items:
+          - File
+          - 'null'
+        type: array
+  - id: contamination
+    default: ''
+    type:
+      - float
+      - 'null'
+  - id: dbsnpVCF
+    default: ''
+    type:
+      - File
+      - 'null'
+  - id: dbsnpVCFIndex
+    default: ''
+    type:
+      - File
+      - 'null'
+  - id: pedigree
+    default: ''
+    type:
+      - File
+      - 'null'
+  - id: ploidy
+    default: ''
+    type:
+      - int
+      - 'null'
+  - id: outputMode
+    default: ''
+    type:
+      - string
+      - 'null'
+  - id: standardMinConfidenceThresholdForCalling
+    default: ''
+    type:
+      - float
+      - 'null'
+  - id: gvcf
+    default: false
+    type: boolean
+  - id: dontUseSoftClippedBases
+    default: false
+    type: boolean
+  - id: javaXmxMb
+    default: 4096
+    type: int
+  - id: timeMinutes
+    default: 400
+    type: int
+  - id: dockerImage
+    default: quay.io/biocontainers/gatk4:4.1.8.0--py38h37ae868_0
+    type: string
+outputs:
+  - id: outputVCF
+    type: File
+    outputBinding:
+        glob: $(inputs.outputPath)
+  - id: outputVCFIndex
+    type: File
+    outputBinding:
+        glob: $(inputs.outputPath).tbi
+requirements:
+  - class: DockerRequirement
+    dockerPull: quay.io/biocontainers/gatk4:4.1.8.0--py38h37ae868_0
+  - class: InitialWorkDirRequirement
+    listing:
+      - entryname: example.sh
+        entry: |4
+
+            set -e
+            mkdir -p "\$(dirname $(inputs.outputPath))"
+            gatk --java-options '-Xmx$(inputs.javaXmxMb)M -XX:ParallelGCThreads=1' \
+            HaplotypeCaller \
+            -R $(inputs.referenceFasta.path) \
+            -O $(inputs.outputPath) \
+            -I ${
+            var text = "";
+            for(var i=0;i<inputs["inputBams"].length;i++) 
+              text+= inputs["inputBams"][i]+" -I ";
+            return text;
+            } \
+            --sample-ploidy $(inputs.ploidy) \
+            $(inputs["intervalList"] === "" ? "": "-L") ${
+            var text = "";
+            for(var i=0;i<inputs["intervalList"].length;i++) 
+              text+= inputs["intervalList"][i]+" -L ";
+            return text;
+            } \
+            $(inputs["excludeIntervalList"] === "" ? "": "-XL") ${
+            var text = "";
+            for(var i=0;i<inputs["excludeIntervalList"].length;i++) 
+              text+= inputs["excludeIntervalList"][i]+" -XL ";
+            return text;
+            } \
+            -D $(inputs.dbsnpVCF) \
+            --pedigree $(inputs.pedigree) \
+            --contamination-fraction-per-sample-file $(inputs.contamination) \
+            --output-mode $(inputs.outputMode) \
+            --emit-ref-confidence $(inputs.emitRefConfidence) \
+            $(inputs["dontUseSoftClippedBases"] ? "--dont-use-soft-clipped-bases" : "") \
+            --standard-min-confidence-threshold-for-calling $(inputs.standardMinConfidenceThresholdForCalling)
+  - class: InlineJavascriptRequirement
+  - class: ToolTimeLimit
+    timelimit: $(inputs.timeMinutes* 60)
+cwlVersion: v1.2
+baseCommand:
+  - sh
+  - example.sh

--- a/wdl2cwl/tests/cwl_files/rtg.cwl
+++ b/wdl2cwl/tests/cwl_files/rtg.cwl
@@ -41,8 +41,10 @@ requirements:
             -o $(inputs.outputPath) \
             ${
             var text = "";
-            for(var i=0;i<inputs["inputFiles"].length;i++) 
+            var arr_length = inputs["inputFiles"].length;
+            for(var i=0;i<arr_length-1;i++) 
               text+= inputs["inputFiles"][i].path+" ";
+            text+= inputs["inputFiles"][arr_length-1].path;
             return text;
             }
   - class: InlineJavascriptRequirement

--- a/wdl2cwl/tests/cwl_files/rtg.cwl
+++ b/wdl2cwl/tests/cwl_files/rtg.cwl
@@ -42,7 +42,7 @@ requirements:
             ${
             var text = "";
             for(var i=0;i<inputs["inputFiles"].length;i++) 
-              text+= inputs["inputFiles"][i]+" ";
+              text+= inputs["inputFiles"][i].path+" ";
             return text;
             }
   - class: InlineJavascriptRequirement

--- a/wdl2cwl/tests/test_cwl.py
+++ b/wdl2cwl/tests/test_cwl.py
@@ -43,6 +43,7 @@ def test_meta(capsys: pytest.CaptureFixture[str]) -> None:
         ("wdl_files/TrimAdapters.wdl", "cwl_files/TrimAdapters.cwl"),
         ("wdl_files/vt.wdl", "cwl_files/vt.cwl"),
         ("wdl_files/transcriptclean_1.wdl", "cwl_files/transcriptclean_1.cwl"),
+        ("wdl_files/gatk_1.wdl", "cwl_files/gatk_1.cwl"),
     ],
 )
 class TestParameterized:

--- a/wdl2cwl/tests/wdl_files/gatk_1.wdl
+++ b/wdl2cwl/tests/wdl_files/gatk_1.wdl
@@ -34,8 +34,8 @@ task HaplotypeCaller {
         #String emitRefConfidence = if gvcf then "GVCF" else "NONE"
         Boolean dontUseSoftClippedBases = false
 
-        #Array[File]+? intervalList
-        #Array[File]+? excludeIntervalList
+        Array[File]+? intervalList
+        Array[File]+? excludeIntervalList
         #Float? contamination
         #File? dbsnpVCF
         #File? dbsnpVCFIndex
@@ -54,11 +54,20 @@ task HaplotypeCaller {
     command {
         set -e
         mkdir -p "$(dirname ~{outputPath})"
+        mkdir wd
+        for FILE in ${sep(" ", inputBams)}; do ln -s $FILE wd/$(inputBams $FILE) ; done
+        for FILE in ${sep(" ", inputBamsIndex)}; do ln -s $FILE wd/$(inputBamsIndex $FILE) ; done
+        mkdir wd2
+        ln -s ~{referenceFasta} wd2/~{basename(referenceFasta)}
+        ln -s ~{referenceFastaDict} wd2/~{basename(referenceFastaDict)}
+        ln -s ~{referenceFastaFai} wd2/~{basename(referenceFastaFai)}
         gatk --java-options '-Xmx~{javaXmxMb}M -XX:ParallelGCThreads=1' \
         HaplotypeCaller \
         -R wd2/~{basename(referenceFasta)} \
         -O ~{outputPath} \
-        -I ~{sep=" -I " inputBams} \
+        (for FILE in ${sep(" ", inputBams)}; do echo -- "-I wd/"$(basename $FILE); done)
+        ~{true="-L" false="" defined(intervalList)} ~{sep=' -L ' intervalList} \
+        ~{true="-XL" false="" defined(excludeIntervalList)} ~{sep=' -XL ' excludeIntervalList} \
         ~{true="--dont-use-soft-clipped-bases" false="" dontUseSoftClippedBases} \
         
     }

--- a/wdl2cwl/tests/wdl_files/gatk_1.wdl
+++ b/wdl2cwl/tests/wdl_files/gatk_1.wdl
@@ -34,15 +34,15 @@ task HaplotypeCaller {
         #String emitRefConfidence = if gvcf then "GVCF" else "NONE"
         Boolean dontUseSoftClippedBases = false
 
-        Array[File]+? intervalList
-        Array[File]+? excludeIntervalList
-        Float? contamination
-        File? dbsnpVCF
-        File? dbsnpVCFIndex
-        File? pedigree
-        Int? ploidy
-        String? outputMode
-        Float? standardMinConfidenceThresholdForCalling
+        #Array[File]+? intervalList
+        #Array[File]+? excludeIntervalList
+        #Float? contamination
+        #File? dbsnpVCF
+        #File? dbsnpVCFIndex
+        #File? pedigree
+        #Int? ploidy
+        #String? outputMode
+        #Float? standardMinConfidenceThresholdForCalling
 
         Int javaXmxMb = 4096
         # Memory increases with time used. 4G should cover most use cases.
@@ -56,19 +56,11 @@ task HaplotypeCaller {
         mkdir -p "$(dirname ~{outputPath})"
         gatk --java-options '-Xmx~{javaXmxMb}M -XX:ParallelGCThreads=1' \
         HaplotypeCaller \
-        -R ~{referenceFasta} \
+        -R wd2/~{basename(referenceFasta)} \
         -O ~{outputPath} \
         -I ~{sep=" -I " inputBams} \
-        ~{"--sample-ploidy " + ploidy} \
-        ~{true="-L" false="" defined(intervalList)} ~{sep=' -L ' intervalList} \
-        ~{true="-XL" false="" defined(excludeIntervalList)} ~{sep=' -XL ' excludeIntervalList} \
-        ~{"-D " + dbsnpVCF} \
-        ~{"--pedigree " + pedigree} \
-        ~{"--contamination-fraction-per-sample-file " + contamination} \
-        ~{"--output-mode " + outputMode} \
-        --emit-ref-confidence ~{emitRefConfidence} \
         ~{true="--dont-use-soft-clipped-bases" false="" dontUseSoftClippedBases} \
-        ~{"--standard-min-confidence-threshold-for-calling " + standardMinConfidenceThresholdForCalling}
+        
     }
 
     output {

--- a/wdl2cwl/tests/wdl_files/gatk_1.wdl
+++ b/wdl2cwl/tests/wdl_files/gatk_1.wdl
@@ -1,0 +1,114 @@
+version 1.0
+
+# Source: https://github.com/biowdl/tasks/blob/bc1bacf11498d2d30b85591cfccdcf71ef0966a5/gatk.wdl#L980
+#
+# Copyright (c) 2018 Leiden University Medical Center
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+task HaplotypeCaller {
+    input {
+        Array[File]+ inputBams
+        Array[File]+ inputBamsIndex
+        String outputPath
+        File referenceFasta
+        File referenceFastaIndex
+        File referenceFastaDict
+        Boolean gvcf = false
+        #String emitRefConfidence = if gvcf then "GVCF" else "NONE"
+        Boolean dontUseSoftClippedBases = false
+
+        Array[File]+? intervalList
+        Array[File]+? excludeIntervalList
+        Float? contamination
+        File? dbsnpVCF
+        File? dbsnpVCFIndex
+        File? pedigree
+        Int? ploidy
+        String? outputMode
+        Float? standardMinConfidenceThresholdForCalling
+
+        Int javaXmxMb = 4096
+        # Memory increases with time used. 4G should cover most use cases.
+        #Int memoryMb = javaXmxMb + 512
+        Int timeMinutes = 400 # This will likely be used with intervals, as such size based estimation can't be used.
+        String dockerImage = "quay.io/biocontainers/gatk4:4.1.8.0--py38h37ae868_0"
+    }
+
+    command {
+        set -e
+        mkdir -p "$(dirname ~{outputPath})"
+        gatk --java-options '-Xmx~{javaXmxMb}M -XX:ParallelGCThreads=1' \
+        HaplotypeCaller \
+        -R ~{referenceFasta} \
+        -O ~{outputPath} \
+        -I ~{sep=" -I " inputBams} \
+        ~{"--sample-ploidy " + ploidy} \
+        ~{true="-L" false="" defined(intervalList)} ~{sep=' -L ' intervalList} \
+        ~{true="-XL" false="" defined(excludeIntervalList)} ~{sep=' -XL ' excludeIntervalList} \
+        ~{"-D " + dbsnpVCF} \
+        ~{"--pedigree " + pedigree} \
+        ~{"--contamination-fraction-per-sample-file " + contamination} \
+        ~{"--output-mode " + outputMode} \
+        --emit-ref-confidence ~{emitRefConfidence} \
+        ~{true="--dont-use-soft-clipped-bases" false="" dontUseSoftClippedBases} \
+        ~{"--standard-min-confidence-threshold-for-calling " + standardMinConfidenceThresholdForCalling}
+    }
+
+    output {
+        File outputVCF = outputPath
+        File outputVCFIndex = outputPath + ".tbi"
+    }
+
+    runtime {
+        #memory: "~{memoryMb}M"
+        time_minutes: timeMinutes
+        docker: dockerImage
+    }
+
+    parameter_meta {
+        # inputs
+        inputBams: {description: "The BAM files on which to perform variant calling.", category: "required"}
+        inputBamsIndex: {description: "The indexes for the input BAM files.", category: "required"}
+        outputPath: {description: "The location to write the output to.", category: "required"}
+        referenceFasta: {description: "The reference fasta file which was also used for mapping.", category: "required"}
+        referenceFastaDict: {description: "The sequence dictionary associated with the reference fasta file.", category: "required"}
+        referenceFastaIndex: {description: "The index for the reference fasta file.", category: "required"}
+        gvcf: {description: "Whether the output should be a gvcf.", category: "common"}
+        emitRefConfidence: {description: "Whether to include reference calls. Three modes: 'NONE', 'BP_RESOLUTION' and 'GVCF'.", category: "advanced"}
+        dontUseSoftClippedBases: {description: "Do not use soft-clipped bases. Should be 'true' for RNA variant calling.", category: "common"}
+        intervalList: {description: "Bed files or interval lists describing the regions to operate on.", category: "common"}
+        excludeIntervalList: {description: "Bed files or interval lists describing the regions to NOT operate on.", category: "common"}
+        contamination: {description: "Equivalent to HaplotypeCaller's `-contamination` option.", category: "advanced"}
+        dbsnpVCF: {description: "A dbSNP VCF.", category: "common"}
+        dbsnpVCFIndex: {description: "The index for the dbSNP VCF.", category: "common"}
+        pedigree: {description: 'Pedigree file for determining the population "founders".', category: "common"}
+        ploidy: {description: "The ploidy with which the variants should be called.", category: "common"}
+        outputMode: {description: "Specifies which type of calls we should output. Same as HaplotypeCaller's `--output-mode` option.", category: "advanced"}
+        standardMinConfidenceThresholdForCalling: {description: "Confidence threshold used for calling variants.", category: "advanced"}
+        javaXmxMb: {description: "The maximum memory available to the program in megabytes. Should be lower than `memoryMb` to accommodate JVM overhead.", category: "advanced"}
+        memoryMb: {description: "The amount of memory this job will use in megabytes.", category: "advanced"}
+        timeMinutes: {description: "The maximum amount of time the job will run in minutes.", category: "advanced"}
+        dockerImage: {description: "The docker image used for this task. Changing this may result in errors which the developers may choose not to address.", category: "advanced"}
+
+        # outputs
+        outputVCF: {description: "Raw, unfiltered SNP and indel calls."}
+        outputVCFIndex: {description: "Index of output VCF."}
+    }
+}


### PR DESCRIPTION
Handles optional array inputs. Added new test case.


- ~~Fix the "" defaults for non-string types~~ Moved to #80 
- [x] The arrays of files should get the .path attribute
- [x] Apply the changes from https://github.com/biowdl/tasks/pull/291/files#diff-c76c01f3ca967cdb9c157a75e7fb1a08d0037543b455c2107398601a2f526ebfR1081 to fix the file co-location error in the original WDL
- [ ] There is an extra prefix for the arrays. The separator should only be added if the current element is not the last one in the array.