### PR TITLE
Handle WDL structs

### DIFF
--- a/wdl2cwl/WdlV1_1ParserVisitor.py
+++ b/wdl2cwl/WdlV1_1ParserVisitor.py
@@ -9,21 +9,19 @@ from typing import List
 # This class defines a complete generic visitor for a parse tree produced by WdlV1_1Parser.
 
 class Struct:
-    """
-    A class to represent WDL's Struct's.
-    """
+    """A class to represent WDL's Struct's."""
 
     def __init__(self, name: str):
-        """
-        :param name: struct name.
-        """
+        """:param name: struct name."""
         self.name = name
         self.fields: List[str] = []
 
 
 class WdlV1_1ParserVisitor(ParseTreeVisitor):
+    """WDL parser AST visitor."""
 
     def __init__(self):
+        """Create a visitor."""
         self.structs = []
         self.task_inputs = []
         self.task_inputs_bound = []

--- a/wdl2cwl/WdlV1_1ParserVisitor.py
+++ b/wdl2cwl/WdlV1_1ParserVisitor.py
@@ -4,12 +4,27 @@ if __name__ is not None and "." in __name__:
     from .WdlV1_1Parser import WdlV1_1Parser
 else:
     from WdlV1_1Parser import WdlV1_1Parser
+from typing import List
 
 # This class defines a complete generic visitor for a parse tree produced by WdlV1_1Parser.
+
+class Struct:
+    """
+    A class to represent WDL's Struct's.
+    """
+
+    def __init__(self, name: str):
+        """
+        :param name: struct name.
+        """
+        self.name = name
+        self.fields: List[str] = []
+
 
 class WdlV1_1ParserVisitor(ParseTreeVisitor):
 
     def __init__(self):
+        self.structs = []
         self.task_inputs = []
         self.task_inputs_bound = []
         self.task_outputs = []
@@ -314,6 +329,11 @@ class WdlV1_1ParserVisitor(ParseTreeVisitor):
 
     # Visit a parse tree produced by WdlV1_1Parser#struct.
     def visitStruct(self, ctx:WdlV1_1Parser.StructContext):
+        """Build a WDL struct to be used later when converting to CWL input/output records."""
+        struct = Struct(name=str(ctx.Identifier()))
+        for decl in ctx.unbound_decls():
+            struct.fields.append([str(decl.Identifier()), decl.wdl_type().getText()])
+        self.structs.append(struct)
         return self.visitChildren(ctx)
 
 

--- a/wdl2cwl/main.py
+++ b/wdl2cwl/main.py
@@ -626,7 +626,7 @@ def convert(workflow: str) -> str:
 
     for s in ast.structs:
         schema = cwl.RecordSchema(
-            type=s.name,
+            type="record",
             fields=[cwl.RecordField(name=f[0], type=f[1]) for f in s.fields],
         )
         record_schemas[s.name] = schema

--- a/wdl2cwl/main.py
+++ b/wdl2cwl/main.py
@@ -1,8 +1,6 @@
 """Main entrypoint for WDL2CWL."""
 import argparse
-from argparse import Namespace
 import sys
-from io import StringIO
 from typing import List, cast, Union, Dict
 from io import StringIO
 import textwrap

--- a/wdl2cwl/main.py
+++ b/wdl2cwl/main.py
@@ -780,7 +780,7 @@ def convert(workflow: str) -> str:
     result_stream = StringIO()
     cwl_result = cat_tool.save()
     scalarstring.walk_tree(cwl_result)
-    # ^ converts multine line strings to nice multiline YAML
+    # ^ converts multiline strings to nice multiline YAML
     yaml.dump(cwl_result, result_stream)
     yaml.dump(cwl_result, sys.stdout)
 

--- a/wdl2cwl/tests/cwl_files/BuildIndices.cwl
+++ b/wdl2cwl/tests/cwl_files/BuildIndices.cwl
@@ -1,0 +1,234 @@
+class: CommandLineTool
+id: BuildIntervalList
+inputs:
+  - id: gtf_version
+    type: string
+  - id: organism
+    type: string
+  - id: organism_prefix
+    type: string
+  - id: gtf_version
+    type: string
+  - id: organism
+    type: string
+  - id: references
+    type:
+        fields:
+          - name: genome_fa
+            type: File
+          - name: annotation_gtf
+            type: File
+        type: References
+  - id: gtf_version
+    type: string
+  - id: organism
+    type: string
+  - id: organism_prefix
+    type: string
+  - id: references
+    type:
+        fields:
+          - name: genome_fa
+            type: File
+          - name: annotation_gtf
+            type: File
+        type: References
+  - id: gtf_version
+    type: string
+  - id: organism
+    type: string
+  - id: references
+    type:
+        fields:
+          - name: genome_fa
+            type: File
+          - name: annotation_gtf
+            type: File
+        type: References
+  - id: rsem_index
+    type: File
+  - id: gtf_version
+    type: string
+  - id: organism
+    type: string
+  - id: genome_fa
+    type: File
+  - id: organism
+    type: string
+  - id: genome_short_string
+    type: string
+  - id: references
+    type:
+        fields:
+          - name: genome_fa
+            type: File
+          - name: annotation_gtf
+            type: File
+        type: References
+  - id: gtf_version
+    type: string
+  - id: dbsnp_version
+    type: string
+  - id: references
+    type:
+        fields:
+          - name: genome_fa
+            type: File
+          - name: annotation_gtf
+            type: File
+        type: References
+  - id: references
+    type:
+        fields:
+          - name: genome_fa
+            type: File
+          - name: annotation_gtf
+            type: File
+        type: References
+outputs:
+  - id: references
+    type:
+        fields:
+          - name: genome_fa
+            type: File
+          - name: annotation_gtf
+            type: File
+        type: References
+  - id: star_index
+    type: File
+    outputBinding:
+        glob: ''
+  - id: star_index
+    type: File
+    outputBinding:
+        glob: ''
+  - id: annotation_gtf_modified_introns
+    type: File
+    outputBinding:
+        glob: ''
+  - id: modified_references
+    type:
+        fields:
+          - name: genome_fa
+            type: File
+          - name: annotation_gtf
+            type: File
+        type: References
+  - id: rsem_index
+    type: File
+    outputBinding:
+        glob: ''
+  - id: hisat2_index
+    type: File
+    outputBinding:
+        glob: ''
+  - id: hisat2_index
+    type: File
+    outputBinding:
+        glob: ''
+  - id: hisat2_index
+    type: File
+    outputBinding:
+        glob: ''
+  - id: refflat
+    type: File
+    outputBinding:
+        glob: ''
+  - id: interval_list
+    type: File
+    outputBinding:
+        glob: ''
+  - id: pipeline_version
+    type: string
+    outputBinding:
+        glob: 0.1.0
+  - id: star_index
+    type: File
+    outputBinding:
+        glob: ''
+  - id: snSS2_star_index
+    type: File
+    outputBinding:
+        glob: ''
+  - id: rsem_index
+    type: File
+    outputBinding:
+        glob: ''
+  - id: hisat2_from_rsem_index
+    type: File
+    outputBinding:
+        glob: ''
+  - id: hisat2_index
+    type: File
+    outputBinding:
+        glob: ''
+  - id: hisat2_snp_haplotype_splicing_index
+    type: File
+    outputBinding:
+        glob: ''
+  - id: refflat
+    type: File
+    outputBinding:
+        glob: ''
+  - id: interval_list
+    type: File
+    outputBinding:
+        glob: ''
+  - id: genome_fa
+    type: File
+    outputBinding:
+        glob: ''
+  - id: annotation_gtf
+    type: File
+    outputBinding:
+        glob: ''
+  - id: snSS2_genome_fa
+    type: File
+    outputBinding:
+        glob: ''
+  - id: snSS2_annotation_gtf
+    type: File
+    outputBinding:
+        glob: ''
+  - id: snSS2_annotation_gtf_introns
+    type: File
+    outputBinding:
+        glob: ''
+requirements:
+  - class: DockerRequirement
+    dockerPull: quay.io/humancellatlas/secondary-analysis-umitools:0.0.1
+  - class: InitialWorkDirRequirement
+    listing:
+      - entryname: example.sh
+        entry: |4+
+
+            set -eo pipefail
+
+
+            # index the fasta file
+
+            samtools faidx $(inputs.references.genome_fa)
+            cut -f1,2 $(inputs.references.genome_fa).fai > sizes.genome
+
+            awk -F '\t'  '{  printf "@SQ\tSN:%s\tLN:%s\n", $1, $2 }' sizes.genome  >> $(inputs.interval_list_name)
+
+            grep 'gene_type "rRNA"' $(inputs.references.annotation_gtf) |
+                awk '$3 == "transcript"' |
+            cut -f1,4,5,7,9 |
+            perl -lane '
+                /transcript_id "([^"]+)"/ or die "no transcript_id on $.";
+                print join "\t", (@F[0,1,2,3], $1)
+            ' |
+            sort -k1V -k2n -k3n  >> $(inputs.interval_list_name)
+
+  - class: InlineJavascriptRequirement
+  - class: NetworkAccess
+    networkAccess: true
+  - class: ResourceRequirement
+    ramMin: 8192
+  - class: ResourceRequirement
+    coresMin: ''
+cwlVersion: v1.2
+baseCommand:
+  - bash
+  - example.sh

--- a/wdl2cwl/tests/cwl_tests.yaml
+++ b/wdl2cwl/tests/cwl_tests.yaml
@@ -24,3 +24,9 @@
       basename: male.vcf.stats
       class: File
       size: 6060
+
+# Tests for doc: BuildIndices
+- doc: BuildIndices
+  tool: cwl_files/BuildIndices.cwl
+  job: inputs/BuildIndices-mouse_inputs.yaml
+  output:

--- a/wdl2cwl/tests/inputs/BuildIndices-mouse_inputs.yaml
+++ b/wdl2cwl/tests/inputs/BuildIndices-mouse_inputs.yaml
@@ -1,0 +1,5 @@
+gtf_version: "M21"
+organism: "mouse"
+organism_prefix: "m"
+genome_short_string: "mm10"
+dbsnp_version: "150"


### PR DESCRIPTION
Closes #72 

Related to #68 too.

**N.B.**: pending tests, but a pre-review before I write the tests to confirm it's going in the right direction is welcome :grimacing: 

This change has minor cosmetics changes (unused imports, typos), and addresses the #72 as follows:

- In the ANTLR parser visitor we create a list of the structs found. This is a list of a custom data class `Struct`, but happy to create a dict/tuple/normal object/etc if it's better
- In the translator, after the tree is “visited”, we convert the list of `Struct` into a dictionary with `key=type_id` (e.g. `References`) and the `value=cwl.RecordSchema`
- In the translator's `get_input`, we pass this dictionary as a new parameter
- The `if`/else` logic in `get_input` we look up the type in the dictionary of records, if a value is found, it will be the type used
- The `get_output` has been renamed to `get_expression_output` as it was not doing the same thing as `get_input`, I think.
- Moved the code that was creating CWL outputs in the `main` function into a new `get_output` function, that looks similar to `get_input`. It handles the structs in the same manner.

<details>
<summary>Resulting workflow using the `warp`'s `BuildIndices.wdl`:</summary>


```
class: CommandLineTool
id: BuildIntervalList
inputs:
  - id: gtf_version
    type: string
  - id: organism
    type: string
  - id: organism_prefix
    type: string
  - id: gtf_version
    type: string
  - id: organism
    type: string
  - id: references
    type:
        fields:
          - name: genome_fa
            type: File
          - name: annotation_gtf
            type: File
        type: References
  - id: gtf_version
    type: string
  - id: organism
    type: string
  - id: organism_prefix
    type: string
  - id: references
    type:
        fields:
          - name: genome_fa
            type: File
          - name: annotation_gtf
            type: File
        type: References
  - id: gtf_version
    type: string
  - id: organism
    type: string
  - id: references
    type:
        fields:
          - name: genome_fa
            type: File
          - name: annotation_gtf
            type: File
        type: References
  - id: rsem_index
    type: File
  - id: gtf_version
    type: string
  - id: organism
    type: string
  - id: genome_fa
    type: File
  - id: organism
    type: string
  - id: genome_short_string
    type: string
  - id: references
    type:
        fields:
          - name: genome_fa
            type: File
          - name: annotation_gtf
            type: File
        type: References
  - id: gtf_version
    type: string
  - id: dbsnp_version
    type: string
  - id: references
    type:
        fields:
          - name: genome_fa
            type: File
          - name: annotation_gtf
            type: File
        type: References
  - id: references
    type:
        fields:
          - name: genome_fa
            type: File
          - name: annotation_gtf
            type: File
        type: References
outputs:
  - id: references
    type:
        fields:
          - name: genome_fa
            type: File
          - name: annotation_gtf
            type: File
        type: References
  - id: star_index
    type: File
    outputBinding:
        glob: ''
  - id: star_index
    type: File
    outputBinding:
        glob: ''
  - id: annotation_gtf_modified_introns
    type: File
    outputBinding:
        glob: ''
  - id: modified_references
    type:
        fields:
          - name: genome_fa
            type: File
          - name: annotation_gtf
            type: File
        type: References
  - id: rsem_index
    type: File
    outputBinding:
        glob: ''
  - id: hisat2_index
    type: File
    outputBinding:
        glob: ''
  - id: hisat2_index
    type: File
    outputBinding:
        glob: ''
  - id: hisat2_index
    type: File
    outputBinding:
        glob: ''
  - id: refflat
    type: File
    outputBinding:
        glob: ''
  - id: interval_list
    type: File
    outputBinding:
        glob: ''
  - id: pipeline_version
    type: string
    outputBinding:
        glob: 0.1.0
  - id: star_index
    type: File
    outputBinding:
        glob: ''
  - id: snSS2_star_index
    type: File
    outputBinding:
        glob: ''
  - id: rsem_index
    type: File
    outputBinding:
        glob: ''
  - id: hisat2_from_rsem_index
    type: File
    outputBinding:
        glob: ''
  - id: hisat2_index
    type: File
    outputBinding:
        glob: ''
  - id: hisat2_snp_haplotype_splicing_index
    type: File
    outputBinding:
        glob: ''
  - id: refflat
    type: File
    outputBinding:
        glob: ''
  - id: interval_list
    type: File
    outputBinding:
        glob: ''
  - id: genome_fa
    type: File
    outputBinding:
        glob: ''
  - id: annotation_gtf
    type: File
    outputBinding:
        glob: ''
  - id: snSS2_genome_fa
    type: File
    outputBinding:
        glob: ''
  - id: snSS2_annotation_gtf
    type: File
    outputBinding:
        glob: ''
  - id: snSS2_annotation_gtf_introns
    type: File
    outputBinding:
        glob: ''
requirements:
  - class: DockerRequirement
    dockerPull: quay.io/humancellatlas/secondary-analysis-umitools:0.0.1
  - class: InitialWorkDirRequirement
    listing:
      - entryname: example.sh
        entry: |4+

            set -eo pipefail


            # index the fasta file

            samtools faidx $(inputs.references.genome_fa)
            cut -f1,2 $(inputs.references.genome_fa).fai > sizes.genome

            awk -F '\t'  '{  printf "@SQ\tSN:%s\tLN:%s\n", $1, $2 }' sizes.genome  >> $(inputs.interval_list_name)

            grep 'gene_type "rRNA"' $(inputs.references.annotation_gtf) |
                awk '$3 == "transcript"' |
            cut -f1,4,5,7,9 |
            perl -lane '
                /transcript_id "([^"]+)"/ or die "no transcript_id on $.";
                print join "\t", (@F[0,1,2,3], $1)
            ' |
            sort -k1V -k2n -k3n  >> $(inputs.interval_list_name)

  - class: InlineJavascriptRequirement
  - class: NetworkAccess
    networkAccess: true
  - class: ResourceRequirement
    ramMin: 8192
  - class: ResourceRequirement
    coresMin: ''
cwlVersion: v1.2
baseCommand:
  - bash
  - example.sh

```
</details>

:point_up: 

Thanks!
Bruno