### PR TITLE
Miniwdl oop

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 cwl-utils
 antlr4-python3-runtime
 regex
+miniwdl

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -3,3 +3,4 @@ pytest-cov
 pytest-xdist
 cwltest
 cwltool
+miniwdl

--- a/wdl2cwl/main.py
+++ b/wdl2cwl/main.py
@@ -10,7 +10,7 @@ import re
 
 import regex  # type: ignore
 
-import cwl_utils.parser_v1_2 as cwl
+import cwl_utils.parser.cwl_v1_2 as cwl
 from antlr4 import CommonTokenStream, InputStream  # type: ignore
 from ruamel.yaml import scalarstring
 from ruamel.yaml.main import YAML

--- a/wdl2cwl/main_oop.py
+++ b/wdl2cwl/main_oop.py
@@ -279,6 +279,8 @@ if __name__ == '__main__':
 
     wdl_command_part_1 = command.parts[0]
     command_1 = textwrap.dedent(wdl_command_part_1)
+    command_1_splitted_p1, command_1_splitted_p2 = command_1.split("$")
+    command_1 = command_1_splitted_p1 + "\\$" + command_1_splitted_p2
     cwl_command_str += command_1
     wdl_command_part_2 = command.parts[1] # This is a wdl.Expr.placeholder object
     command_2_expr = wdl_command_part_2.expr.expr.name

--- a/wdl2cwl/main_oop.py
+++ b/wdl2cwl/main_oop.py
@@ -126,7 +126,7 @@ class Converter:
     def translate_command_string(self, string: WDL.Expr.String):
         # print("this is the literal", string.literal)
         # if string.literal is not None:
-        #     return str(string.literal).lstrip('"').rstrip('"')
+        #     return str(string.literal).lstrip("').rstrip('"')
 
         # elements = {}
         # counter = 1
@@ -282,7 +282,7 @@ if __name__ == '__main__':
     cwl_command_str += command_1
     wdl_command_part_2 = command.parts[1] # This is a wdl.Expr.placeholder object
     command_2_expr = wdl_command_part_2.expr.expr.name
-    cwl_command_str += "$(inputs." + command_2_expr + ")"
+    cwl_command_str += "$(inputs." + command_2_expr + " )"
     wdl_command_part_3 = command.parts[2]
     command_3 = textwrap.dedent(wdl_command_part_3)
     cwl_command_str += command_3
@@ -293,7 +293,7 @@ if __name__ == '__main__':
     command_4_input_value_name = command_4_input_value.expr.name
 
     # Since command_4_arg_value.expr.referee.type.optional == True
-    cwl_command_str += "$(inputs." + command_4_input_value_name + ' === null ? "" : ' + f"'{command_4_arg_name_value}'"  + " inputs." + command_4_input_value_name + ")"
+    cwl_command_str += "$(inputs." + command_4_input_value_name + ' === null ? "" : ' + f'"{command_4_arg_name_value}"'  + " inputs." + command_4_input_value_name + " )"
     wdl_command_part_5 = command.parts[4]
     command_5 = textwrap.dedent(wdl_command_part_5)
     cwl_command_str += command_5
@@ -304,7 +304,7 @@ if __name__ == '__main__':
     command_6_input_value_name = command_6_input_value.expr.name
 
     # Since command_6_arg_value.expr.referee.type.optional == True
-    cwl_command_str += "$(inputs." + command_6_input_value_name + ' === null ? "" : ' + f"'{command_6_arg_name_value}'"  + " inputs." + command_6_input_value_name + ")"
+    cwl_command_str += "$(inputs." + command_6_input_value_name + ' === null ? "" : ' + f'"{command_6_arg_name_value}"'  + " inputs." + command_6_input_value_name + " )"
  
     wdl_command_part_7 = command.parts[6]
     command_7 = textwrap.dedent(wdl_command_part_7)
@@ -316,7 +316,7 @@ if __name__ == '__main__':
     command_8_input_value_name = command_8_input_value.expr.name
 
     # Since command_4_arg_value.expr.referee.type.optional == True
-    cwl_command_str += "$(inputs." + command_8_input_value_name + ' === null ? "" : ' + f"'{command_8_arg_name_value}'"  + " inputs." + command_8_input_value_name + ")"
+    cwl_command_str += "$(inputs." + command_8_input_value_name + ' === null ? "" : ' + f'"{command_8_arg_name_value}"'  + " inputs." + command_8_input_value_name + " )"
 
     wdl_command_part_9 = command.parts[8]
     command_9 = textwrap.dedent(wdl_command_part_9)
@@ -325,21 +325,21 @@ if __name__ == '__main__':
 
     # Since wdl_command_part_10.options = {'true': '--best', 'false': '""'}
     command_10_expr = wdl_command_part_10.expr.expr.name
-    cwl_command_str += "$(inputs." + command_10_expr + " ? " + "'{true_value}' : '{false_value}')".format(true_value=wdl_command_part_10.options["true"], false_value=wdl_command_part_10.options["false"]) + ")"
+    cwl_command_str += "$(inputs." + command_10_expr + " ? " + '"{true_value}" : "{false_value}")'.format(true_value=wdl_command_part_10.options["true"], false_value=wdl_command_part_10.options["false"]) + ")"
     wdl_command_part_11 = command.parts[10]
     command_11 = textwrap.dedent(wdl_command_part_11)
     cwl_command_str += command_11
     wdl_command_part_12 = command.parts[11]
     command_12_expr = wdl_command_part_12.expr.expr.name
 # Since wdl_command_part_12.options = {'true': '--best', 'false': '""'}
-    cwl_command_str += "$(inputs." + command_12_expr + " ? " + "'{true_value}' : '{false_value}')".format(true_value=wdl_command_part_12.options["true"], false_value=wdl_command_part_12.options["false"]) + ")"
+    cwl_command_str += "$(inputs." + command_12_expr + " ? " + '"{true_value}" : "{false_value}")'.format(true_value=wdl_command_part_12.options["true"], false_value=wdl_command_part_12.options["false"]) + ")"
     wdl_command_part_13 = command.parts[12]
     command_13 = textwrap.dedent(wdl_command_part_13)
     cwl_command_str += command_13
     wdl_command_part_14 = command.parts[13]
     command_14_expr = wdl_command_part_14.expr.expr.name
 # Since wdl_command_part_14.options = {'true': '--best', 'false': '""
-    cwl_command_str += "$(inputs." + command_14_expr + " ? " + "'{true_value}' : '{false_value}')".format(true_value=wdl_command_part_14.options["true"], false_value=wdl_command_part_14.options["false"]) + ")"
+    cwl_command_str += "$(inputs." + command_14_expr + " ? " + '"{true_value}" : "{false_value}")'.format(true_value=wdl_command_part_14.options["true"], false_value=wdl_command_part_14.options["false"]) + ")"
     wdl_command_part_15 = command.parts[14]
     command_15 = textwrap.dedent(wdl_command_part_15)
     cwl_command_str += command_15
@@ -350,7 +350,7 @@ if __name__ == '__main__':
     command_16_input_value_name = command_16_input_value.expr.name
 
     # Since command_4_arg_value.expr.referee.type.optional == True
-    cwl_command_str += "$(inputs." + command_16_input_value_name + ' === null ? "" : ' + f"'{command_16_arg_name_value}'"  + " inputs." + command_16_input_value_name + ")"
+    cwl_command_str += "$(inputs." + command_16_input_value_name + ' === null ? "" : ' + f'"{command_16_arg_name_value}"'  + " inputs." + command_16_input_value_name + " )"
 
     wdl_command_part_17 = command.parts[16]
     command_17 = textwrap.dedent(wdl_command_part_17)
@@ -362,15 +362,73 @@ if __name__ == '__main__':
     command_18_input_value_name = command_18_input_value.expr.name
 
     # Since command_4_arg_value.expr.referee.type.optional == True
-    cwl_command_str += "$(inputs." + command_18_input_value_name + ' === null ? "" : ' + f"'{command_18_arg_name_value}'"  + " inputs." + command_18_input_value_name + ")"
+    cwl_command_str += "$(inputs." + command_18_input_value_name + ' === null ? "" : ' + f'"{command_18_arg_name_value}"'  + " inputs." + command_18_input_value_name + " )"
 
+
+    # Special cases present...the false_valaue should bome before the true value
     wdl_command_part_19 = command.parts[18]
+    command_19_expr = wdl_command_part_19.expr.arguments[0].expr.referee.name
+# Since wdl_command_part_14.options = {'true': '--best', 'false': '""
+    cwl_command_str += "$(inputs." + command_19_expr + " ? " + '"{false_value}" : "{true_value}")'.format(true_value=wdl_command_part_19.options["true"], false_value=wdl_command_part_19.options["false"])
+
+    wdl_command_part_20 = command.parts[19]
+    command_20 = textwrap.dedent(wdl_command_part_20)
+    cwl_command_str += command_20
+
+    wdl_command_part_21 = command.parts[20]
+    wdl_command_part_21_expr = wdl_command_part_21
+    wdl_command_part_21_func_name = wdl_command_part_21_expr.expr.function_name
+    wdl_command_part_21_arg = wdl_command_part_21_expr.expr.arguments
+    wdl_command_part_21_arg_1, wdl_command_part_21_arg_2, wdl_command_part_21_arg_3 = wdl_command_part_21_arg
+    
+    # since function_name is sub
+    wdl_command_part_21_arg_1_input_name, wdl_command_part_21_arg_1_index = wdl_command_part_21_arg_1.arguments
+    command_21 = '$(inputs.' + wdl_command_part_21_arg_1_input_name.expr.name + f'[{wdl_command_part_21_arg_1_index.value}]' + f'.replace( "{wdl_command_part_21_arg_2.literal.value}", "{wdl_command_part_21_arg_3.literal.value}") )'
+    cwl_command_str += command_21
+
+    wdl_command_part_22 = command.parts[21]
+    command_22 = textwrap.dedent(wdl_command_part_22)
+    cwl_command_str += command_22
+
+    wdl_command_part_23 = command.parts[22]
+    wdl_command_part_23_input_name = wdl_command_part_23.expr.expr.name
+    wdl_command_part_23_seperator = wdl_command_part_23.options["sep"]
+    command_23 = f'$(inputs.{wdl_command_part_23_input_name}.map(' + 'function(el) {return el.path}).join("' + wdl_command_part_23_seperator + '"))'
+    cwl_command_str += command_23
+
+    wdl_command_part_24 = command.parts[23]
+    command_24 = textwrap.dedent(wdl_command_part_24)
+    cwl_command_str += command_24
+
+    wdl_command_part_25 = command.parts[24]
+    cwl_command_str += "$(inputs." + wdl_command_part_25.expr.expr.name + ") "
+
+    wdl_command_part_26 = command.parts[25]
+    command_26 = textwrap.dedent(wdl_command_part_26)
+    cwl_command_str += command_26
+
+    wdl_command_part_27 = command.parts[26]
+    cwl_command_str += "$(inputs." + wdl_command_part_27.expr.expr.name + ") "
+
+    wdl_command_part_28 = command.parts[27]
+    command_28 = textwrap.dedent(wdl_command_part_28)
+    cwl_command_str += command_28
 
     requirements.append(
         cwl.InitialWorkDirRequirement(
             listing=[cwl.Dirent(entry=cwl_command_str, entryname="example.sh")]
         )
     )
+    requirements.append(cwl.InlineJavascriptRequirement())
+    requirements.append(cwl.NetworkAccess(networkAccess=True))
+
+    wdl_runtime_cpu = task.runtime["cpu"].expr.name
+    ram_min = f'$(inputs.{wdl_runtime_cpu})'
+    requirements.append(
+            cwl.ResourceRequirement(
+                ramMin=ram_min,
+            )
+        )
     # Resulting cwl output
     base_command = ["bash", "example.sh"]
 

--- a/wdl2cwl/main_oop.py
+++ b/wdl2cwl/main_oop.py
@@ -1,6 +1,6 @@
 import os
 from typing import List, Union, Optional, Callable
-import WDL
+import WDL # type: ignore
 import cwl_utils.parser.cwl_v1_2 as cwl
 
 from io import StringIO

--- a/wdl2cwl/main_oop.py
+++ b/wdl2cwl/main_oop.py
@@ -1,0 +1,192 @@
+import os
+from typing import List, Union, Optional, Callable
+import WDL
+import cwl_utils.parser.cwl_v1_2 as cwl
+
+from io import StringIO
+import textwrap
+import re
+
+from ruamel.yaml import scalarstring
+from ruamel.yaml.main import YAML
+
+
+# WDL-CWL Type Mappings
+wdl_type = {
+    "Array[String]": "string[]",
+    "String": "string",
+    "File": "File",
+    "Int": "int",
+    "Float": "float",
+    "Boolean": "boolean",
+}
+
+
+
+class Converter:
+
+    @staticmethod
+    def load_wdl_tree(doc: str):
+        wdl_path = os.path.relpath(doc)
+        doc_tree = WDL.load(wdl_path)
+
+
+        parser = Converter()
+
+        if doc_tree.workflow:
+            return parser.load_wdl_objects(doc_tree.workflow)
+        
+        tasks = []
+        for task in doc_tree.tasks:
+            tasks.append(parser.load_wdl_objects(task))
+
+        return tasks[0]
+
+    def load_wdl_objects(self, obj: WDL.SourceNode):
+        if isinstance(obj, WDL.Task):
+            return self.load_wdl_task(obj)
+        elif isinstance(obj, WDL.Workflow):
+            return self.load_wdl_workflow(obj)
+
+    def load_wdl_workflow(self, obj: WDL.Workflow):
+        print(f"Workflow {obj.name} loaded")
+    
+    def load_wdl_task(self, obj: WDL.Task):
+        inputs = obj.inputs
+        runtime = obj.runtime
+
+        # command = self.translate_command(obj.command, inputs)
+        # print(f"Task {obj.name} loaded")
+        # print(obj.__dict__)
+        raw_inputs = self.get_raw_inputs(obj.inputs)
+        inputs = self.get_inputs(raw_inputs)
+        base_command = ["bash", "example.sh"]
+
+        cat_tool = cwl.CommandLineTool(
+        id=obj.name,
+        inputs=inputs,
+        requirements=None,
+        outputs=[],
+        cwlVersion="v1.2",
+        baseCommand=base_command,
+        )
+
+        yaml = YAML()
+        yaml.default_flow_style = False
+        yaml.indent = 4
+        yaml.block_seq_indent = 2
+        result_stream = StringIO()
+        cwl_result = cat_tool.save()
+        scalarstring.walk_tree(cwl_result)
+        yaml.dump(cwl_result, result_stream)
+        yaml.dump(cwl_result, sys.stdout)
+
+        return result_stream.getvalue()
+    
+    def get_raw_inputs(self, input_declarations: List[str]):
+        raw_inputs = []
+
+        for input_declaration in input_declarations:
+            split_str = str(input_declaration).split(" ")
+            type_of, name, *expression = split_str
+
+            if expression: 
+                expression = "".join(expression[1:])
+            else: 
+                expression = None
+
+            raw_inputs.append([type_of, name, expression])
+
+        return raw_inputs
+
+    def get_inputs(self, raw_inputs: List[str]):
+        inputs: List[cwl.CommandInputParameter]
+
+        for raw_input in raw_inputs:
+            if raw_input[2] is None:
+                input_name = raw_input[1]
+
+                if "Array" in raw_input[0]:
+                    temp_type = wdl_type[
+                        raw_input[0][raw_input[0].find("[") + 1 : raw_input[0].find("]")].replace('"', "")
+                    ]
+                    input_type = temp_type if "?" not in raw_input[0] else [temp_type, "null"]
+                    input_name = raw_input[1]
+
+                    inputs.append(
+                        cwl.CommandInputParameter(
+                            id=input_name,
+                            type=[cwl.CommandInputArraySchema(items=input_type, type="array")],
+                        )
+                    )
+
+                else:
+                    input_type = (
+                        wdl_type[raw_input[0]]
+                        if "?" not in raw_input[0]
+                        else [wdl_type[raw_input[0].replace("?", "")], "null"]
+                    )
+
+                    inputs.append(cwl.CommandInputParameter(id=input_name, type=input_type))
+
+        return inputs
+        
+
+    def translate_command(self, expr: WDL.Expr.Base, inputs: List[str]):
+
+        if expr is None:
+            return None
+        
+        if isinstance(expr, WDL.Expr.Array):
+            return [self.translate_expr(e) for e in expr.items]
+
+        if isinstance(expr, WDL.Expr.String):
+            return self.translate_command_string(expr)
+        elif isinstance(expr, (WDL.Expr.Int, WDL.Expr.Boolean, WDL.Expr.Float)):
+            return self.literal.value
+        if isinstance(expr, WDL.Expr.Placeholder):
+            return self.translate_expr(expr.expr)
+
+
+
+    def translate_command_string(self, string: WDL.Expr.String):
+        # print("this is the literal", string.literal)
+        # if string.literal is not None:
+        #     return str(string.literal).lstrip('"').rstrip('"')
+
+        # elements = {}
+        # counter = 1
+        # _format = str(string).lstrip('"').rstrip('"')
+        # print("from _format", _format)
+
+        # for placeholder in string.children:
+
+
+        #     print(placeholder)
+        pass
+
+
+
+
+if __name__ == '__main__':
+    import sys
+    import argparse
+    
+    
+    # Command-line parsing.
+    parser = argparse.ArgumentParser()
+    parser.add_argument("workflow", help="Path to WDL workflow")
+
+    # args = parser.parse_args()
+
+
+    try:
+        converted = Converter.load_wdl_tree("wdl2cwl/tests/wdl_files/bowtie_1.wdl")
+        # converted = Converter.load_wdl_tree(args.workflow)
+    except WDL.Error.SyntaxError as err:
+        print(err)
+    except WDL.Error.ValidationError as err:
+        print(err)
+    except WDL.Error.MultipleValidationErrors as err:
+        for error in err.exceptions:
+            print(error)

--- a/wdl2cwl/main_oop.py
+++ b/wdl2cwl/main_oop.py
@@ -275,12 +275,102 @@ if __name__ == '__main__':
             cwl.DockerRequirement(dockerPull=dockerpull)
         )
     command = task.command
+    cwl_command_str = ""
 
     wdl_command_part_1 = command.parts[0]
     command_1 = textwrap.dedent(wdl_command_part_1)
-    wdl_command_part_2 = command.parts[1] # This is a wdl.Expr.placeholder
-    command_2_expr = wdl_command_part_2.expr
+    cwl_command_str += command_1
+    wdl_command_part_2 = command.parts[1] # This is a wdl.Expr.placeholder object
+    command_2_expr = wdl_command_part_2.expr.expr.name
+    cwl_command_str += "$(inputs." + command_2_expr + ")"
+    wdl_command_part_3 = command.parts[2]
+    command_3 = textwrap.dedent(wdl_command_part_3)
+    cwl_command_str += command_3
+    wdl_command_part_4 = command.parts[3]
 
+    command_4_arg_name, command_4_input_value = wdl_command_part_4.expr.arguments # This is a wdl.Expr.apply object
+    command_4_arg_name_value = command_4_arg_name.literal.value
+    command_4_input_value_name = command_4_input_value.expr.name
+
+    # Since command_4_arg_value.expr.referee.type.optional == True
+    cwl_command_str += "$(inputs." + command_4_input_value_name + ' === null ? "" : ' + f"'{command_4_arg_name_value}'"  + " inputs." + command_4_input_value_name + ")"
+    wdl_command_part_5 = command.parts[4]
+    command_5 = textwrap.dedent(wdl_command_part_5)
+    cwl_command_str += command_5
+    wdl_command_part_6 = command.parts[5]
+
+    command_6_arg_name, command_6_input_value = wdl_command_part_6.expr.arguments # This is a wdl.Expr.apply object
+    command_6_arg_name_value = command_6_arg_name.literal.value
+    command_6_input_value_name = command_6_input_value.expr.name
+
+    # Since command_6_arg_value.expr.referee.type.optional == True
+    cwl_command_str += "$(inputs." + command_6_input_value_name + ' === null ? "" : ' + f"'{command_6_arg_name_value}'"  + " inputs." + command_6_input_value_name + ")"
+ 
+    wdl_command_part_7 = command.parts[6]
+    command_7 = textwrap.dedent(wdl_command_part_7)
+    cwl_command_str += command_7
+
+    wdl_command_part_8 = command.parts[7]
+    command_8_arg_name, command_8_input_value = wdl_command_part_8.expr.arguments # This is a wdl.Expr.apply object
+    command_8_arg_name_value = command_8_arg_name.literal.value
+    command_8_input_value_name = command_8_input_value.expr.name
+
+    # Since command_4_arg_value.expr.referee.type.optional == True
+    cwl_command_str += "$(inputs." + command_8_input_value_name + ' === null ? "" : ' + f"'{command_8_arg_name_value}'"  + " inputs." + command_8_input_value_name + ")"
+
+    wdl_command_part_9 = command.parts[8]
+    command_9 = textwrap.dedent(wdl_command_part_9)
+    cwl_command_str += command_9
+    wdl_command_part_10 = command.parts[9]
+
+    # Since wdl_command_part_10.options = {'true': '--best', 'false': '""'}
+    command_10_expr = wdl_command_part_10.expr.expr.name
+    cwl_command_str += "$(inputs." + command_10_expr + " ? " + "'{true_value}' : '{false_value}')".format(true_value=wdl_command_part_10.options["true"], false_value=wdl_command_part_10.options["false"]) + ")"
+    wdl_command_part_11 = command.parts[10]
+    command_11 = textwrap.dedent(wdl_command_part_11)
+    cwl_command_str += command_11
+    wdl_command_part_12 = command.parts[11]
+    command_12_expr = wdl_command_part_12.expr.expr.name
+# Since wdl_command_part_12.options = {'true': '--best', 'false': '""'}
+    cwl_command_str += "$(inputs." + command_12_expr + " ? " + "'{true_value}' : '{false_value}')".format(true_value=wdl_command_part_12.options["true"], false_value=wdl_command_part_12.options["false"]) + ")"
+    wdl_command_part_13 = command.parts[12]
+    command_13 = textwrap.dedent(wdl_command_part_13)
+    cwl_command_str += command_13
+    wdl_command_part_14 = command.parts[13]
+    command_14_expr = wdl_command_part_14.expr.expr.name
+# Since wdl_command_part_14.options = {'true': '--best', 'false': '""
+    cwl_command_str += "$(inputs." + command_14_expr + " ? " + "'{true_value}' : '{false_value}')".format(true_value=wdl_command_part_14.options["true"], false_value=wdl_command_part_14.options["false"]) + ")"
+    wdl_command_part_15 = command.parts[14]
+    command_15 = textwrap.dedent(wdl_command_part_15)
+    cwl_command_str += command_15
+    wdl_command_part_16 = command.parts[15]
+
+    command_16_arg_name, command_16_input_value = wdl_command_part_16.expr.arguments # This is a wdl.Expr.apply object
+    command_16_arg_name_value = command_16_arg_name.literal.value
+    command_16_input_value_name = command_16_input_value.expr.name
+
+    # Since command_4_arg_value.expr.referee.type.optional == True
+    cwl_command_str += "$(inputs." + command_16_input_value_name + ' === null ? "" : ' + f"'{command_16_arg_name_value}'"  + " inputs." + command_16_input_value_name + ")"
+
+    wdl_command_part_17 = command.parts[16]
+    command_17 = textwrap.dedent(wdl_command_part_17)
+    cwl_command_str += command_17
+    wdl_command_part_18 = command.parts[17]
+
+    command_18_arg_name, command_18_input_value = wdl_command_part_18.expr.arguments # This is a wdl.Expr.apply object
+    command_18_arg_name_value = command_18_arg_name.literal.value
+    command_18_input_value_name = command_18_input_value.expr.name
+
+    # Since command_4_arg_value.expr.referee.type.optional == True
+    cwl_command_str += "$(inputs." + command_18_input_value_name + ' === null ? "" : ' + f"'{command_18_arg_name_value}'"  + " inputs." + command_18_input_value_name + ")"
+
+    wdl_command_part_19 = command.parts[18]
+
+    requirements.append(
+        cwl.InitialWorkDirRequirement(
+            listing=[cwl.Dirent(entry=cwl_command_str, entryname="example.sh")]
+        )
+    )
     # Resulting cwl output
     base_command = ["bash", "example.sh"]
 

--- a/wdl2cwl/main_oop.py
+++ b/wdl2cwl/main_oop.py
@@ -23,18 +23,16 @@ wdl_type = {
 
 
 class Converter:
-
     @staticmethod
     def load_wdl_tree(doc: str):
         wdl_path = os.path.relpath(doc)
         doc_tree = WDL.load(wdl_path)
 
-
         parser = Converter()
 
         if doc_tree.workflow:
             return parser.load_wdl_objects(doc_tree.workflow)
-        
+
         tasks = []
         for task in doc_tree.tasks:
             tasks.append(parser.load_wdl_objects(task))
@@ -49,20 +47,20 @@ class Converter:
 
     def load_wdl_workflow(self, obj: WDL.Workflow):
         print(f"Workflow {obj.name} loaded")
-    
+
     def load_wdl_task(self, obj: WDL.Task):
         runtime = obj.runtime
-        
+
         cwl_inputs = self.get_cwl_inputs(obj.inputs)
         base_command = ["bash", "example.sh"]
 
         cat_tool = cwl.CommandLineTool(
-        id=obj.name,
-        inputs=cwl_inputs,
-        requirements=None,
-        outputs=[],
-        cwlVersion="v1.2",
-        baseCommand=base_command,
+            id=obj.name,
+            inputs=cwl_inputs,
+            requirements=None,
+            outputs=[],
+            cwlVersion="v1.2",
+            baseCommand=base_command,
         )
 
         yaml = YAML()
@@ -85,7 +83,7 @@ class Converter:
             input_value = None
 
             if isinstance(wdl_input.type, WDL.Type.Array):
-                input_type = 'File'
+                input_type = "File"
                 type_of = [cwl.CommandInputArraySchema(items=input_type, type="array")]
             elif isinstance(wdl_input.type, WDL.Type.String):
                 type_of = "string"
@@ -96,21 +94,25 @@ class Converter:
             else:
                 type_of = "unknown type"
 
+            if wdl_input.type.optional:
+                type_of = [type_of, "null"]
 
-            if wdl_input.type.optional: type_of = [type_of, "null"]
+            if wdl_input.expr is not None:
+                input_value = wdl_input.expr.literal.value
 
-            if wdl_input.expr is not None: input_value = wdl_input.expr.literal.value
-
-            inputs.append(cwl.CommandInputParameter(id=input_name, type=type_of, default=input_value))
+            inputs.append(
+                cwl.CommandInputParameter(
+                    id=input_name, type=type_of, default=input_value
+                )
+            )
 
         return inputs
-        
 
     def translate_command(self, expr: WDL.Expr.Base, inputs: List[str]):
 
         if expr is None:
             return None
-        
+
         if isinstance(expr, WDL.Expr.Array):
             return [self.translate_expr(e) for e in expr.items]
 
@@ -120,8 +122,6 @@ class Converter:
             return self.literal.value
         if isinstance(expr, WDL.Expr.Placeholder):
             return self.translate_expr(expr.expr)
-
-
 
     def translate_command_string(self, string: WDL.Expr.String):
         # print("this is the literal", string.literal)
@@ -135,26 +135,21 @@ class Converter:
 
         # for placeholder in string.children:
 
-
         #     print(placeholder)
         pass
 
 
-
-
-if __name__ == '__main__':
+if __name__ == "__main__":
     import sys
     import argparse
-    
 
-    
     # Command-line parsing.
     parser = argparse.ArgumentParser()
     parser.add_argument("workflow", help="Path to WDL workflow")
+    parser.add_argument("-o", "--output", help="Name of resultant CWL file")
+    args = parser.parse_args()
 
-    # args = parser.parse_args()
-
-    wdl_path = "wdl2cwl/tests/wdl_files/bowtie_1.wdl"
+    wdl_path = args.workflow
     doc_tree = WDL.load(wdl_path)
     task = doc_tree.tasks[0]
     inputs = task.inputs
@@ -165,115 +160,120 @@ if __name__ == '__main__':
     # add a function to return the cwl type from wdl_type using isinstance
 
     cwl_inputs.append(
-                cwl.CommandInputParameter(
-                    id=wdl_first_input.name,
-                    type=[cwl.CommandInputArraySchema(items="File", type="array")],
-                )
-            )
+        cwl.CommandInputParameter(
+            id=wdl_first_input.name,
+            type=[cwl.CommandInputArraySchema(items="File", type="array")],
+        )
+    )
     wdl_second_input = inputs[1]
     cwl_inputs.append(
-                cwl.CommandInputParameter(
-                    id=wdl_second_input.name,
-                    type="string", default=wdl_second_input.expr.literal.value
-                )
-            )
+        cwl.CommandInputParameter(
+            id=wdl_second_input.name,
+            type="string",
+            default=wdl_second_input.expr.literal.value,
+        )
+    )
     wdl_third_input = inputs[2]
     cwl_inputs.append(
-                cwl.CommandInputParameter(
-                    id=wdl_third_input.name,
-                    type=[cwl.CommandInputArraySchema(items="File", type="array")],
-                )
-            )
+        cwl.CommandInputParameter(
+            id=wdl_third_input.name,
+            type=[cwl.CommandInputArraySchema(items="File", type="array")],
+        )
+    )
     wdl_fourth_input = inputs[3]
     cwl_inputs.append(
-                cwl.CommandInputParameter(
-                    id=wdl_fourth_input.name,
-                    type="boolean", default=wdl_fourth_input.expr.literal.value
-                )
-            )
+        cwl.CommandInputParameter(
+            id=wdl_fourth_input.name,
+            type="boolean",
+            default=wdl_fourth_input.expr.literal.value,
+        )
+    )
     wdl_fifth_input = inputs[4]
     cwl_inputs.append(
-                cwl.CommandInputParameter(
-                    id=wdl_fifth_input.name,
-                    type="boolean", default=wdl_fifth_input.expr.literal.value
-                )
-            )
+        cwl.CommandInputParameter(
+            id=wdl_fifth_input.name,
+            type="boolean",
+            default=wdl_fifth_input.expr.literal.value,
+        )
+    )
     wdl_sixth_input = inputs[5]
     cwl_inputs.append(
-                cwl.CommandInputParameter(
-                    id=wdl_sixth_input.name,
-                    type="boolean", default=wdl_sixth_input.expr.literal.value
-                )
-            )
+        cwl.CommandInputParameter(
+            id=wdl_sixth_input.name,
+            type="boolean",
+            default=wdl_sixth_input.expr.literal.value,
+        )
+    )
     wdl_seventh_input = inputs[6]
     cwl_inputs.append(
-                cwl.CommandInputParameter(
-                    id=wdl_seventh_input.name,
-                    type=["int", "null"], default=None
-                )
-            )
+        cwl.CommandInputParameter(
+            id=wdl_seventh_input.name, type=["int", "null"], default=None
+        )
+    )
     wdl_eight_input = inputs[7]
     # since wdl_eight_input.type.optional == True then we return an array with null appended
     cwl_inputs.append(
-                cwl.CommandInputParameter(
-                    id=wdl_eight_input.name,
-                    type=["int", "null"], default=None
-                )
-            )
+        cwl.CommandInputParameter(
+            id=wdl_eight_input.name, type=["int", "null"], default=None
+        )
+    )
     wdl_nineth_input = inputs[8]
     cwl_inputs.append(
-                cwl.CommandInputParameter(
-                    id=wdl_nineth_input.name,
-                    type=["int", "null"], default=None
-                )
-            )
+        cwl.CommandInputParameter(
+            id=wdl_nineth_input.name, type=["int", "null"], default=None
+        )
+    )
     wdl_tenth_input = inputs[9]
     cwl_inputs.append(
-                cwl.CommandInputParameter(
-                    id=wdl_tenth_input.name,
-                    type=["string", "null"], default=None
-                )
-            )
+        cwl.CommandInputParameter(
+            id=wdl_tenth_input.name, type=["string", "null"], default=None
+        )
+    )
     wdl_eleventh_input = inputs[10]
     cwl_inputs.append(
-                cwl.CommandInputParameter(
-                    id=wdl_eleventh_input.name,
-                    type="string", default=wdl_eleventh_input.expr.literal.value
-                )
-            )
+        cwl.CommandInputParameter(
+            id=wdl_eleventh_input.name,
+            type="string",
+            default=wdl_eleventh_input.expr.literal.value,
+        )
+    )
     wdl_twelveth_input = inputs[11]
     cwl_inputs.append(
-                cwl.CommandInputParameter(
-                    id=wdl_twelveth_input.name,
-                    type="int", default=wdl_twelveth_input.expr.literal.value
-                )
-            )
+        cwl.CommandInputParameter(
+            id=wdl_twelveth_input.name,
+            type="int",
+            default=wdl_twelveth_input.expr.literal.value,
+        )
+    )
     wdl_thirteenth_input = inputs[12]
     cwl_inputs.append(
-                cwl.CommandInputParameter(
-                    id=wdl_thirteenth_input.name,
-                    type="string", default=wdl_thirteenth_input.expr.literal.value
-                )
-            )
-    
+        cwl.CommandInputParameter(
+            id=wdl_thirteenth_input.name,
+            type="string",
+            default=wdl_thirteenth_input.expr.literal.value,
+        )
+    )
+
     wdl_outputs = task.outputs
     cwl_outputs = []
     wdl_first_output = wdl_outputs[0]
 
     cwl_outputs.append(
-    cwl.CommandOutputParameter(
-        id=wdl_first_output.name,
-        type="File",
-        outputBinding=cwl.CommandOutputBinding(glob="$(inputs.{outputpath})".format(outputpath=wdl_first_output.expr.expr.name)),
+        cwl.CommandOutputParameter(
+            id=wdl_first_output.name,
+            type="File",
+            outputBinding=cwl.CommandOutputBinding(
+                glob="$(inputs.{outputpath})".format(
+                    outputpath=wdl_first_output.expr.expr.name
+                )
+            ),
         )
     )
 
     requirements: List[cwl.ProcessRequirement] = []
 
     dockerpull = task.runtime["docker"].expr.referee.expr.literal.value
-    requirements.append(
-            cwl.DockerRequirement(dockerPull=dockerpull)
-        )
+    requirements.append(cwl.DockerRequirement(dockerPull=dockerpull))
     command = task.command
     cwl_command_str = ""
 
@@ -282,7 +282,7 @@ if __name__ == '__main__':
     command_1_splitted_p1, command_1_splitted_p2 = command_1.split("$")
     command_1 = command_1_splitted_p1 + "\\$" + command_1_splitted_p2
     cwl_command_str += command_1
-    wdl_command_part_2 = command.parts[1] # This is a wdl.Expr.placeholder object
+    wdl_command_part_2 = command.parts[1]  # This is a wdl.Expr.placeholder object
     command_2_expr = wdl_command_part_2.expr.expr.name
     cwl_command_str += "$(inputs." + command_2_expr + " )"
     wdl_command_part_3 = command.parts[2]
@@ -290,35 +290,68 @@ if __name__ == '__main__':
     cwl_command_str += command_3
     wdl_command_part_4 = command.parts[3]
 
-    command_4_arg_name, command_4_input_value = wdl_command_part_4.expr.arguments # This is a wdl.Expr.apply object
+    (
+        command_4_arg_name,
+        command_4_input_value,
+    ) = wdl_command_part_4.expr.arguments  # This is a wdl.Expr.apply object
     command_4_arg_name_value = command_4_arg_name.literal.value
     command_4_input_value_name = command_4_input_value.expr.name
 
     # Since command_4_arg_value.expr.referee.type.optional == True
-    cwl_command_str += "$(inputs." + command_4_input_value_name + ' === null ? "" : ' + f'"{command_4_arg_name_value}"'  + " inputs." + command_4_input_value_name + " )"
+    cwl_command_str += (
+        "$(inputs."
+        + command_4_input_value_name
+        + ' === null ? "" : '
+        + f'"{command_4_arg_name_value}"'
+        + " inputs."
+        + command_4_input_value_name
+        + " )"
+    )
     wdl_command_part_5 = command.parts[4]
     command_5 = textwrap.dedent(wdl_command_part_5)
     cwl_command_str += command_5
     wdl_command_part_6 = command.parts[5]
 
-    command_6_arg_name, command_6_input_value = wdl_command_part_6.expr.arguments # This is a wdl.Expr.apply object
+    (
+        command_6_arg_name,
+        command_6_input_value,
+    ) = wdl_command_part_6.expr.arguments  # This is a wdl.Expr.apply object
     command_6_arg_name_value = command_6_arg_name.literal.value
     command_6_input_value_name = command_6_input_value.expr.name
 
     # Since command_6_arg_value.expr.referee.type.optional == True
-    cwl_command_str += "$(inputs." + command_6_input_value_name + ' === null ? "" : ' + f'"{command_6_arg_name_value}"'  + " inputs." + command_6_input_value_name + " )"
- 
+    cwl_command_str += (
+        "$(inputs."
+        + command_6_input_value_name
+        + ' === null ? "" : '
+        + f'"{command_6_arg_name_value}"'
+        + " inputs."
+        + command_6_input_value_name
+        + " )"
+    )
+
     wdl_command_part_7 = command.parts[6]
     command_7 = textwrap.dedent(wdl_command_part_7)
     cwl_command_str += command_7
 
     wdl_command_part_8 = command.parts[7]
-    command_8_arg_name, command_8_input_value = wdl_command_part_8.expr.arguments # This is a wdl.Expr.apply object
+    (
+        command_8_arg_name,
+        command_8_input_value,
+    ) = wdl_command_part_8.expr.arguments  # This is a wdl.Expr.apply object
     command_8_arg_name_value = command_8_arg_name.literal.value
     command_8_input_value_name = command_8_input_value.expr.name
 
     # Since command_4_arg_value.expr.referee.type.optional == True
-    cwl_command_str += "$(inputs." + command_8_input_value_name + ' === null ? "" : ' + f'"{command_8_arg_name_value}"'  + " inputs." + command_8_input_value_name + " )"
+    cwl_command_str += (
+        "$(inputs."
+        + command_8_input_value_name
+        + ' === null ? "" : '
+        + f'"{command_8_arg_name_value}"'
+        + " inputs."
+        + command_8_input_value_name
+        + " )"
+    )
 
     wdl_command_part_9 = command.parts[8]
     command_9 = textwrap.dedent(wdl_command_part_9)
@@ -327,51 +360,107 @@ if __name__ == '__main__':
 
     # Since wdl_command_part_10.options = {'true': '--best', 'false': '""'}
     command_10_expr = wdl_command_part_10.expr.expr.name
-    cwl_command_str += "$(inputs." + command_10_expr + " ? " + '"{true_value}" : "{false_value}")'.format(true_value=wdl_command_part_10.options["true"], false_value=wdl_command_part_10.options["false"]) + ")"
+    cwl_command_str += (
+        "$(inputs."
+        + command_10_expr
+        + " ? "
+        + '"{true_value}" : "{false_value}")'.format(
+            true_value=wdl_command_part_10.options["true"],
+            false_value=wdl_command_part_10.options["false"],
+        )
+        + ")"
+    )
     wdl_command_part_11 = command.parts[10]
     command_11 = textwrap.dedent(wdl_command_part_11)
     cwl_command_str += command_11
     wdl_command_part_12 = command.parts[11]
     command_12_expr = wdl_command_part_12.expr.expr.name
-# Since wdl_command_part_12.options = {'true': '--best', 'false': '""'}
-    cwl_command_str += "$(inputs." + command_12_expr + " ? " + '"{true_value}" : "{false_value}")'.format(true_value=wdl_command_part_12.options["true"], false_value=wdl_command_part_12.options["false"]) + ")"
+    # Since wdl_command_part_12.options = {'true': '--best', 'false': '""'}
+    cwl_command_str += (
+        "$(inputs."
+        + command_12_expr
+        + " ? "
+        + '"{true_value}" : "{false_value}")'.format(
+            true_value=wdl_command_part_12.options["true"],
+            false_value=wdl_command_part_12.options["false"],
+        )
+        + ")"
+    )
     wdl_command_part_13 = command.parts[12]
     command_13 = textwrap.dedent(wdl_command_part_13)
     cwl_command_str += command_13
     wdl_command_part_14 = command.parts[13]
     command_14_expr = wdl_command_part_14.expr.expr.name
-# Since wdl_command_part_14.options = {'true': '--best', 'false': '""
-    cwl_command_str += "$(inputs." + command_14_expr + " ? " + '"{true_value}" : "{false_value}")'.format(true_value=wdl_command_part_14.options["true"], false_value=wdl_command_part_14.options["false"]) + ")"
+    # Since wdl_command_part_14.options = {'true': '--best', 'false': '""
+    cwl_command_str += (
+        "$(inputs."
+        + command_14_expr
+        + " ? "
+        + '"{true_value}" : "{false_value}")'.format(
+            true_value=wdl_command_part_14.options["true"],
+            false_value=wdl_command_part_14.options["false"],
+        )
+        + ")"
+    )
     wdl_command_part_15 = command.parts[14]
     command_15 = textwrap.dedent(wdl_command_part_15)
     cwl_command_str += command_15
     wdl_command_part_16 = command.parts[15]
 
-    command_16_arg_name, command_16_input_value = wdl_command_part_16.expr.arguments # This is a wdl.Expr.apply object
+    (
+        command_16_arg_name,
+        command_16_input_value,
+    ) = wdl_command_part_16.expr.arguments  # This is a wdl.Expr.apply object
     command_16_arg_name_value = command_16_arg_name.literal.value
     command_16_input_value_name = command_16_input_value.expr.name
 
     # Since command_4_arg_value.expr.referee.type.optional == True
-    cwl_command_str += "$(inputs." + command_16_input_value_name + ' === null ? "" : ' + f'"{command_16_arg_name_value}"'  + " inputs." + command_16_input_value_name + " )"
+    cwl_command_str += (
+        "$(inputs."
+        + command_16_input_value_name
+        + ' === null ? "" : '
+        + f'"{command_16_arg_name_value}"'
+        + " inputs."
+        + command_16_input_value_name
+        + " )"
+    )
 
     wdl_command_part_17 = command.parts[16]
     command_17 = textwrap.dedent(wdl_command_part_17)
     cwl_command_str += command_17
     wdl_command_part_18 = command.parts[17]
 
-    command_18_arg_name, command_18_input_value = wdl_command_part_18.expr.arguments # This is a wdl.Expr.apply object
+    (
+        command_18_arg_name,
+        command_18_input_value,
+    ) = wdl_command_part_18.expr.arguments  # This is a wdl.Expr.apply object
     command_18_arg_name_value = command_18_arg_name.literal.value
     command_18_input_value_name = command_18_input_value.expr.name
 
     # Since command_4_arg_value.expr.referee.type.optional == True
-    cwl_command_str += "$(inputs." + command_18_input_value_name + ' === null ? "" : ' + f'"{command_18_arg_name_value}"'  + " inputs." + command_18_input_value_name + " )"
-
+    cwl_command_str += (
+        "$(inputs."
+        + command_18_input_value_name
+        + ' === null ? "" : '
+        + f'"{command_18_arg_name_value}"'
+        + " inputs."
+        + command_18_input_value_name
+        + " )"
+    )
 
     # Special cases present...the false_valaue should bome before the true value
     wdl_command_part_19 = command.parts[18]
     command_19_expr = wdl_command_part_19.expr.arguments[0].expr.referee.name
-# Since wdl_command_part_14.options = {'true': '--best', 'false': '""
-    cwl_command_str += "$(inputs." + command_19_expr + " ? " + '"{false_value}" : "{true_value}")'.format(true_value=wdl_command_part_19.options["true"], false_value=wdl_command_part_19.options["false"])
+    # Since wdl_command_part_14.options = {'true': '--best', 'false': '""
+    cwl_command_str += (
+        "$(inputs."
+        + command_19_expr
+        + " ? "
+        + '"{false_value}" : "{true_value}")'.format(
+            true_value=wdl_command_part_19.options["true"],
+            false_value=wdl_command_part_19.options["false"],
+        )
+    )
 
     wdl_command_part_20 = command.parts[19]
     command_20 = textwrap.dedent(wdl_command_part_20)
@@ -381,11 +470,23 @@ if __name__ == '__main__':
     wdl_command_part_21_expr = wdl_command_part_21
     wdl_command_part_21_func_name = wdl_command_part_21_expr.expr.function_name
     wdl_command_part_21_arg = wdl_command_part_21_expr.expr.arguments
-    wdl_command_part_21_arg_1, wdl_command_part_21_arg_2, wdl_command_part_21_arg_3 = wdl_command_part_21_arg
-    
+    (
+        wdl_command_part_21_arg_1,
+        wdl_command_part_21_arg_2,
+        wdl_command_part_21_arg_3,
+    ) = wdl_command_part_21_arg
+
     # since function_name is sub
-    wdl_command_part_21_arg_1_input_name, wdl_command_part_21_arg_1_index = wdl_command_part_21_arg_1.arguments
-    command_21 = '$(inputs.' + wdl_command_part_21_arg_1_input_name.expr.name + f'[{wdl_command_part_21_arg_1_index.value}]' + f'.replace( "{wdl_command_part_21_arg_2.literal.value}", "{wdl_command_part_21_arg_3.literal.value}") )'
+    (
+        wdl_command_part_21_arg_1_input_name,
+        wdl_command_part_21_arg_1_index,
+    ) = wdl_command_part_21_arg_1.arguments
+    command_21 = (
+        "$(inputs."
+        + wdl_command_part_21_arg_1_input_name.expr.name
+        + f"[{wdl_command_part_21_arg_1_index.value}]"
+        + f'.replace( "{wdl_command_part_21_arg_2.literal.value}", "{wdl_command_part_21_arg_3.literal.value}") )'
+    )
     cwl_command_str += command_21
 
     wdl_command_part_22 = command.parts[21]
@@ -395,7 +496,12 @@ if __name__ == '__main__':
     wdl_command_part_23 = command.parts[22]
     wdl_command_part_23_input_name = wdl_command_part_23.expr.expr.name
     wdl_command_part_23_seperator = wdl_command_part_23.options["sep"]
-    command_23 = f'$(inputs.{wdl_command_part_23_input_name}.map(' + 'function(el) {return el.path}).join("' + wdl_command_part_23_seperator + '"))'
+    command_23 = (
+        f"$(inputs.{wdl_command_part_23_input_name}.map("
+        + 'function(el) {return el.path}).join("'
+        + wdl_command_part_23_seperator
+        + '"))'
+    )
     cwl_command_str += command_23
 
     wdl_command_part_24 = command.parts[23]
@@ -425,22 +531,22 @@ if __name__ == '__main__':
     requirements.append(cwl.NetworkAccess(networkAccess=True))
 
     wdl_runtime_cpu = task.runtime["cpu"].expr.name
-    ram_min = f'$(inputs.{wdl_runtime_cpu})'
+    ram_min = f"$(inputs.{wdl_runtime_cpu})"
     requirements.append(
-            cwl.ResourceRequirement(
-                ramMin=ram_min,
-            )
+        cwl.ResourceRequirement(
+            ramMin=ram_min,
         )
+    )
     # Resulting cwl output
     base_command = ["bash", "example.sh"]
 
     cat_tool = cwl.CommandLineTool(
-    id=task.name,
-    inputs=cwl_inputs,
-    requirements=requirements,
-    outputs=cwl_outputs,
-    cwlVersion="v1.2",
-    baseCommand=base_command,
+        id=task.name,
+        inputs=cwl_inputs,
+        requirements=requirements,
+        outputs=cwl_outputs,
+        cwlVersion="v1.2",
+        baseCommand=base_command,
     )
 
     yaml = YAML()
@@ -456,8 +562,9 @@ if __name__ == '__main__':
     result_stream.getvalue()
 
     # write to a file in oop_cwl_files
-    with open("wdl2cwl/tests/oop_cwl_files/bowtie_1.cwl", "w") as result:
-        result.write(result_stream.getvalue())
+    if args.output:
+        with open(args.output, "w") as result:
+            result.write(result_stream.getvalue())
 
     # try:
     #     converted = Converter.load_wdl_tree("wdl2cwl/tests/wdl_files/bowtie_1.wdl")

--- a/wdl2cwl/main_oop.py
+++ b/wdl2cwl/main_oop.py
@@ -557,7 +557,7 @@ def convert(path: str) -> str:
 
 
 def main() -> None:
-    """Main entry point."""
+    """Entry point."""
     # Command-line parsing.
     parser = argparse.ArgumentParser()
     parser.add_argument("workflow", help="Path to WDL workflow")

--- a/wdl2cwl/main_oop.py
+++ b/wdl2cwl/main_oop.py
@@ -268,7 +268,18 @@ if __name__ == '__main__':
         )
     )
 
+    requirements: List[cwl.ProcessRequirement] = []
 
+    dockerpull = task.runtime["docker"].expr.referee.expr.literal.value
+    requirements.append(
+            cwl.DockerRequirement(dockerPull=dockerpull)
+        )
+    command = task.command
+
+    wdl_command_part_1 = command.parts[0]
+    command_1 = textwrap.dedent(wdl_command_part_1)
+    wdl_command_part_2 = command.parts[1] # This is a wdl.Expr.placeholder
+    command_2_expr = wdl_command_part_2.expr
 
     # Resulting cwl output
     base_command = ["bash", "example.sh"]
@@ -276,7 +287,7 @@ if __name__ == '__main__':
     cat_tool = cwl.CommandLineTool(
     id=task.name,
     inputs=cwl_inputs,
-    requirements=None,
+    requirements=requirements,
     outputs=cwl_outputs,
     cwlVersion="v1.2",
     baseCommand=base_command,

--- a/wdl2cwl/main_oop.py
+++ b/wdl2cwl/main_oop.py
@@ -6,6 +6,9 @@ import cwl_utils.parser.cwl_v1_2 as cwl
 from io import StringIO
 import textwrap
 import re
+import sys
+import argparse
+
 
 from ruamel.yaml import scalarstring
 from ruamel.yaml.main import YAML
@@ -137,436 +140,437 @@ from ruamel.yaml.main import YAML
 
 #         #     print(placeholder)
 #         pass
+def convert(path: str) -> str:
+    """convert just the bowtie_1 file."""
+    wdl_path = path
+    doc_tree = WDL.load(wdl_path)
+    task = doc_tree.tasks[0]
+    inputs = task.inputs
+    wdl_first_input = inputs[0]
+
+    cwl_inputs: List[cwl.CommandInputParameter] = []
+
+    # add a function to return the cwl type from wdl_type using isinstance
+
+    cwl_inputs.append(
+        cwl.CommandInputParameter(
+            id=wdl_first_input.name,
+            type=[cwl.CommandInputArraySchema(items="File", type="array")],
+        )
+    )
+    wdl_second_input = inputs[1]
+    cwl_inputs.append(
+        cwl.CommandInputParameter(
+            id=wdl_second_input.name,
+            type="string",
+            default=wdl_second_input.expr.literal.value,
+        )
+    )
+    wdl_third_input = inputs[2]
+    cwl_inputs.append(
+        cwl.CommandInputParameter(
+            id=wdl_third_input.name,
+            type=[cwl.CommandInputArraySchema(items="File", type="array")],
+        )
+    )
+    wdl_fourth_input = inputs[3]
+    cwl_inputs.append(
+        cwl.CommandInputParameter(
+            id=wdl_fourth_input.name,
+            type="boolean",
+            default=wdl_fourth_input.expr.literal.value,
+        )
+    )
+    wdl_fifth_input = inputs[4]
+    cwl_inputs.append(
+        cwl.CommandInputParameter(
+            id=wdl_fifth_input.name,
+            type="boolean",
+            default=wdl_fifth_input.expr.literal.value,
+        )
+    )
+    wdl_sixth_input = inputs[5]
+    cwl_inputs.append(
+        cwl.CommandInputParameter(
+            id=wdl_sixth_input.name,
+            type="boolean",
+            default=wdl_sixth_input.expr.literal.value,
+        )
+    )
+    wdl_seventh_input = inputs[6]
+    cwl_inputs.append(
+        cwl.CommandInputParameter(
+            id=wdl_seventh_input.name, type=["int", "null"], default=None
+        )
+    )
+    wdl_eight_input = inputs[7]
+    # since wdl_eight_input.type.optional == True then we return an array with null appended
+    cwl_inputs.append(
+        cwl.CommandInputParameter(
+            id=wdl_eight_input.name, type=["int", "null"], default=None
+        )
+    )
+    wdl_nineth_input = inputs[8]
+    cwl_inputs.append(
+        cwl.CommandInputParameter(
+            id=wdl_nineth_input.name, type=["int", "null"], default=None
+        )
+    )
+    wdl_tenth_input = inputs[9]
+    cwl_inputs.append(
+        cwl.CommandInputParameter(
+            id=wdl_tenth_input.name, type=["string", "null"], default=None
+        )
+    )
+    wdl_eleventh_input = inputs[10]
+    cwl_inputs.append(
+        cwl.CommandInputParameter(
+            id=wdl_eleventh_input.name,
+            type="string",
+            default=wdl_eleventh_input.expr.literal.value,
+        )
+    )
+    wdl_twelveth_input = inputs[11]
+    cwl_inputs.append(
+        cwl.CommandInputParameter(
+            id=wdl_twelveth_input.name,
+            type="int",
+            default=wdl_twelveth_input.expr.literal.value,
+        )
+    )
+    wdl_thirteenth_input = inputs[12]
+    cwl_inputs.append(
+        cwl.CommandInputParameter(
+            id=wdl_thirteenth_input.name,
+            type="string",
+            default=wdl_thirteenth_input.expr.literal.value,
+        )
+    )
+
+    wdl_outputs = task.outputs
+    cwl_outputs = []
+    wdl_first_output = wdl_outputs[0]
+
+    cwl_outputs.append(
+        cwl.CommandOutputParameter(
+            id=wdl_first_output.name,
+            type="File",
+            outputBinding=cwl.CommandOutputBinding(
+                glob="$(inputs.{outputpath})".format(
+                    outputpath=wdl_first_output.expr.expr.name
+                )
+            ),
+        )
+    )
+
+    requirements: List[cwl.ProcessRequirement] = []
+
+    dockerpull = task.runtime["docker"].expr.referee.expr.literal.value
+    requirements.append(cwl.DockerRequirement(dockerPull=dockerpull))
+    command = task.command
+    cwl_command_str = ""
+
+    wdl_command_part_1 = command.parts[0]
+    command_1 = textwrap.dedent(wdl_command_part_1)
+    command_1_splitted_p1, command_1_splitted_p2 = command_1.split("$")
+    command_1 = command_1_splitted_p1 + "\\$" + command_1_splitted_p2
+    cwl_command_str += command_1
+    wdl_command_part_2 = command.parts[1]  # This is a wdl.Expr.placeholder object
+    command_2_expr = wdl_command_part_2.expr.expr.name
+    cwl_command_str += "$(inputs." + command_2_expr + " )"
+    wdl_command_part_3 = command.parts[2]
+    command_3 = textwrap.dedent(wdl_command_part_3)
+    cwl_command_str += command_3
+    wdl_command_part_4 = command.parts[3]
+
+    (
+        command_4_arg_name,
+        command_4_input_value,
+    ) = wdl_command_part_4.expr.arguments  # This is a wdl.Expr.apply object
+    command_4_arg_name_value = command_4_arg_name.literal.value
+    command_4_input_value_name = command_4_input_value.expr.name
+
+    # Since command_4_arg_value.expr.referee.type.optional == True
+    cwl_command_str += (
+        "$(inputs."
+        + command_4_input_value_name
+        + ' === null ? "" : '
+        + f'"{command_4_arg_name_value}"'
+        + " inputs."
+        + command_4_input_value_name
+        + " )"
+    )
+    wdl_command_part_5 = command.parts[4]
+    command_5 = textwrap.dedent(wdl_command_part_5)
+    cwl_command_str += command_5
+    wdl_command_part_6 = command.parts[5]
+
+    (
+        command_6_arg_name,
+        command_6_input_value,
+    ) = wdl_command_part_6.expr.arguments  # This is a wdl.Expr.apply object
+    command_6_arg_name_value = command_6_arg_name.literal.value
+    command_6_input_value_name = command_6_input_value.expr.name
+
+    # Since command_6_arg_value.expr.referee.type.optional == True
+    cwl_command_str += (
+        "$(inputs."
+        + command_6_input_value_name
+        + ' === null ? "" : '
+        + f'"{command_6_arg_name_value}"'
+        + " inputs."
+        + command_6_input_value_name
+        + " )"
+    )
+
+    wdl_command_part_7 = command.parts[6]
+    command_7 = textwrap.dedent(wdl_command_part_7)
+    cwl_command_str += command_7
+
+    wdl_command_part_8 = command.parts[7]
+    (
+        command_8_arg_name,
+        command_8_input_value,
+    ) = wdl_command_part_8.expr.arguments  # This is a wdl.Expr.apply object
+    command_8_arg_name_value = command_8_arg_name.literal.value
+    command_8_input_value_name = command_8_input_value.expr.name
+
+    # Since command_4_arg_value.expr.referee.type.optional == True
+    cwl_command_str += (
+        "$(inputs."
+        + command_8_input_value_name
+        + ' === null ? "" : '
+        + f'"{command_8_arg_name_value}"'
+        + " inputs."
+        + command_8_input_value_name
+        + " )"
+    )
+
+    wdl_command_part_9 = command.parts[8]
+    command_9 = textwrap.dedent(wdl_command_part_9)
+    cwl_command_str += command_9
+    wdl_command_part_10 = command.parts[9]
+
+    # Since wdl_command_part_10.options = {'true': '--best', 'false': '""'}
+    command_10_expr = wdl_command_part_10.expr.expr.name
+    cwl_command_str += (
+        "$(inputs."
+        + command_10_expr
+        + " ? "
+        + '"{true_value}" : "{false_value}")'.format(
+            true_value=wdl_command_part_10.options["true"],
+            false_value=wdl_command_part_10.options["false"],
+        )
+        + ")"
+    )
+    wdl_command_part_11 = command.parts[10]
+    command_11 = textwrap.dedent(wdl_command_part_11)
+    cwl_command_str += command_11
+    wdl_command_part_12 = command.parts[11]
+    command_12_expr = wdl_command_part_12.expr.expr.name
+    # Since wdl_command_part_12.options = {'true': '--best', 'false': '""'}
+    cwl_command_str += (
+        "$(inputs."
+        + command_12_expr
+        + " ? "
+        + '"{true_value}" : "{false_value}")'.format(
+            true_value=wdl_command_part_12.options["true"],
+            false_value=wdl_command_part_12.options["false"],
+        )
+        + ")"
+    )
+    wdl_command_part_13 = command.parts[12]
+    command_13 = textwrap.dedent(wdl_command_part_13)
+    cwl_command_str += command_13
+    wdl_command_part_14 = command.parts[13]
+    command_14_expr = wdl_command_part_14.expr.expr.name
+    # Since wdl_command_part_14.options = {'true': '--best', 'false': '""
+    cwl_command_str += (
+        "$(inputs."
+        + command_14_expr
+        + " ? "
+        + '"{true_value}" : "{false_value}")'.format(
+            true_value=wdl_command_part_14.options["true"],
+            false_value=wdl_command_part_14.options["false"],
+        )
+        + ")"
+    )
+    wdl_command_part_15 = command.parts[14]
+    command_15 = textwrap.dedent(wdl_command_part_15)
+    cwl_command_str += command_15
+    wdl_command_part_16 = command.parts[15]
+
+    (
+        command_16_arg_name,
+        command_16_input_value,
+    ) = wdl_command_part_16.expr.arguments  # This is a wdl.Expr.apply object
+    command_16_arg_name_value = command_16_arg_name.literal.value
+    command_16_input_value_name = command_16_input_value.expr.name
+
+    # Since command_4_arg_value.expr.referee.type.optional == True
+    cwl_command_str += (
+        "$(inputs."
+        + command_16_input_value_name
+        + ' === null ? "" : '
+        + f'"{command_16_arg_name_value}"'
+        + " inputs."
+        + command_16_input_value_name
+        + " )"
+    )
+
+    wdl_command_part_17 = command.parts[16]
+    command_17 = textwrap.dedent(wdl_command_part_17)
+    cwl_command_str += command_17
+    wdl_command_part_18 = command.parts[17]
+
+    (
+        command_18_arg_name,
+        command_18_input_value,
+    ) = wdl_command_part_18.expr.arguments  # This is a wdl.Expr.apply object
+    command_18_arg_name_value = command_18_arg_name.literal.value
+    command_18_input_value_name = command_18_input_value.expr.name
+
+    # Since command_4_arg_value.expr.referee.type.optional == True
+    cwl_command_str += (
+        "$(inputs."
+        + command_18_input_value_name
+        + ' === null ? "" : '
+        + f'"{command_18_arg_name_value}"'
+        + " inputs."
+        + command_18_input_value_name
+        + " )"
+    )
+
+    # Special cases present...the false_valaue should bome before the true value
+    wdl_command_part_19 = command.parts[18]
+    command_19_expr = wdl_command_part_19.expr.arguments[0].expr.referee.name
+    # Since wdl_command_part_14.options = {'true': '--best', 'false': '""
+    cwl_command_str += (
+        "$(inputs."
+        + command_19_expr
+        + " ? "
+        + '"{false_value}" : "{true_value}")'.format(
+            true_value=wdl_command_part_19.options["true"],
+            false_value=wdl_command_part_19.options["false"],
+        )
+    )
+
+    wdl_command_part_20 = command.parts[19]
+    command_20 = textwrap.dedent(wdl_command_part_20)
+    cwl_command_str += command_20
+
+    wdl_command_part_21 = command.parts[20]
+    wdl_command_part_21_expr = wdl_command_part_21
+    wdl_command_part_21_func_name = wdl_command_part_21_expr.expr.function_name
+    wdl_command_part_21_arg = wdl_command_part_21_expr.expr.arguments
+    (
+        wdl_command_part_21_arg_1,
+        wdl_command_part_21_arg_2,
+        wdl_command_part_21_arg_3,
+    ) = wdl_command_part_21_arg
+
+    # since function_name is sub
+    (
+        wdl_command_part_21_arg_1_input_name,
+        wdl_command_part_21_arg_1_index,
+    ) = wdl_command_part_21_arg_1.arguments
+    command_21 = (
+        "$(inputs."
+        + wdl_command_part_21_arg_1_input_name.expr.name
+        + f"[{wdl_command_part_21_arg_1_index.value}]"
+        + f'.replace( "{wdl_command_part_21_arg_2.literal.value}", "{wdl_command_part_21_arg_3.literal.value}") )'
+    )
+    cwl_command_str += command_21
+
+    wdl_command_part_22 = command.parts[21]
+    command_22 = textwrap.dedent(wdl_command_part_22)
+    cwl_command_str += command_22
+
+    wdl_command_part_23 = command.parts[22]
+    wdl_command_part_23_input_name = wdl_command_part_23.expr.expr.name
+    wdl_command_part_23_seperator = wdl_command_part_23.options["sep"]
+    command_23 = (
+        f"$(inputs.{wdl_command_part_23_input_name}.map("
+        + 'function(el) {return el.path}).join("'
+        + wdl_command_part_23_seperator
+        + '"))'
+    )
+    cwl_command_str += command_23
+
+    wdl_command_part_24 = command.parts[23]
+    command_24 = textwrap.dedent(wdl_command_part_24)
+    cwl_command_str += command_24
+
+    wdl_command_part_25 = command.parts[24]
+    cwl_command_str += "$(inputs." + wdl_command_part_25.expr.expr.name + ") "
+
+    wdl_command_part_26 = command.parts[25]
+    command_26 = textwrap.dedent(wdl_command_part_26)
+    cwl_command_str += command_26
+
+    wdl_command_part_27 = command.parts[26]
+    cwl_command_str += "$(inputs." + wdl_command_part_27.expr.expr.name + ") "
+
+    wdl_command_part_28 = command.parts[27]
+    command_28 = textwrap.dedent(wdl_command_part_28)
+    cwl_command_str += command_28
+
+    requirements.append(
+        cwl.InitialWorkDirRequirement(
+            listing=[cwl.Dirent(entry=cwl_command_str, entryname="example.sh")]
+        )
+    )
+    requirements.append(cwl.InlineJavascriptRequirement())
+    requirements.append(cwl.NetworkAccess(networkAccess=True))
+
+    wdl_runtime_cpu = task.runtime["cpu"].expr.name
+    ram_min = f"$(inputs.{wdl_runtime_cpu})"
+    requirements.append(
+        cwl.ResourceRequirement(
+            ramMin=ram_min,
+        )
+    )
+    # Resulting cwl output
+    base_command = ["bash", "example.sh"]
+
+    cat_tool = cwl.CommandLineTool(
+        id=task.name,
+        inputs=cwl_inputs,
+        requirements=requirements,
+        outputs=cwl_outputs,
+        cwlVersion="v1.2",
+        baseCommand=base_command,
+    )
+
+    yaml = YAML()
+    yaml.default_flow_style = False
+    yaml.indent = 4
+    yaml.block_seq_indent = 2
+    result_stream = StringIO()
+    cwl_result = cat_tool.save()
+    scalarstring.walk_tree(cwl_result)
+    yaml.dump(cwl_result, result_stream)
+    yaml.dump(cwl_result, sys.stdout)
+
+    return result_stream.getvalue()
 
 
-if __name__ == "__main__":
-    import sys
-    import argparse
-
+def main() -> None:
+    """The main entry point."""
     # Command-line parsing.
     parser = argparse.ArgumentParser()
     parser.add_argument("workflow", help="Path to WDL workflow")
     parser.add_argument("-o", "--output", help="Name of resultant CWL file")
     args = parser.parse_args()
-
-    def convert(path: str) -> str:
-        wdl_path = path
-        doc_tree = WDL.load(wdl_path)
-        task = doc_tree.tasks[0]
-        inputs = task.inputs
-        wdl_first_input = inputs[0]
-
-        cwl_inputs: List[cwl.CommandInputParameter] = []
-
-        # add a function to return the cwl type from wdl_type using isinstance
-
-        cwl_inputs.append(
-            cwl.CommandInputParameter(
-                id=wdl_first_input.name,
-                type=[cwl.CommandInputArraySchema(items="File", type="array")],
-            )
-        )
-        wdl_second_input = inputs[1]
-        cwl_inputs.append(
-            cwl.CommandInputParameter(
-                id=wdl_second_input.name,
-                type="string",
-                default=wdl_second_input.expr.literal.value,
-            )
-        )
-        wdl_third_input = inputs[2]
-        cwl_inputs.append(
-            cwl.CommandInputParameter(
-                id=wdl_third_input.name,
-                type=[cwl.CommandInputArraySchema(items="File", type="array")],
-            )
-        )
-        wdl_fourth_input = inputs[3]
-        cwl_inputs.append(
-            cwl.CommandInputParameter(
-                id=wdl_fourth_input.name,
-                type="boolean",
-                default=wdl_fourth_input.expr.literal.value,
-            )
-        )
-        wdl_fifth_input = inputs[4]
-        cwl_inputs.append(
-            cwl.CommandInputParameter(
-                id=wdl_fifth_input.name,
-                type="boolean",
-                default=wdl_fifth_input.expr.literal.value,
-            )
-        )
-        wdl_sixth_input = inputs[5]
-        cwl_inputs.append(
-            cwl.CommandInputParameter(
-                id=wdl_sixth_input.name,
-                type="boolean",
-                default=wdl_sixth_input.expr.literal.value,
-            )
-        )
-        wdl_seventh_input = inputs[6]
-        cwl_inputs.append(
-            cwl.CommandInputParameter(
-                id=wdl_seventh_input.name, type=["int", "null"], default=None
-            )
-        )
-        wdl_eight_input = inputs[7]
-        # since wdl_eight_input.type.optional == True then we return an array with null appended
-        cwl_inputs.append(
-            cwl.CommandInputParameter(
-                id=wdl_eight_input.name, type=["int", "null"], default=None
-            )
-        )
-        wdl_nineth_input = inputs[8]
-        cwl_inputs.append(
-            cwl.CommandInputParameter(
-                id=wdl_nineth_input.name, type=["int", "null"], default=None
-            )
-        )
-        wdl_tenth_input = inputs[9]
-        cwl_inputs.append(
-            cwl.CommandInputParameter(
-                id=wdl_tenth_input.name, type=["string", "null"], default=None
-            )
-        )
-        wdl_eleventh_input = inputs[10]
-        cwl_inputs.append(
-            cwl.CommandInputParameter(
-                id=wdl_eleventh_input.name,
-                type="string",
-                default=wdl_eleventh_input.expr.literal.value,
-            )
-        )
-        wdl_twelveth_input = inputs[11]
-        cwl_inputs.append(
-            cwl.CommandInputParameter(
-                id=wdl_twelveth_input.name,
-                type="int",
-                default=wdl_twelveth_input.expr.literal.value,
-            )
-        )
-        wdl_thirteenth_input = inputs[12]
-        cwl_inputs.append(
-            cwl.CommandInputParameter(
-                id=wdl_thirteenth_input.name,
-                type="string",
-                default=wdl_thirteenth_input.expr.literal.value,
-            )
-        )
-
-        wdl_outputs = task.outputs
-        cwl_outputs = []
-        wdl_first_output = wdl_outputs[0]
-
-        cwl_outputs.append(
-            cwl.CommandOutputParameter(
-                id=wdl_first_output.name,
-                type="File",
-                outputBinding=cwl.CommandOutputBinding(
-                    glob="$(inputs.{outputpath})".format(
-                        outputpath=wdl_first_output.expr.expr.name
-                    )
-                ),
-            )
-        )
-
-        requirements: List[cwl.ProcessRequirement] = []
-
-        dockerpull = task.runtime["docker"].expr.referee.expr.literal.value
-        requirements.append(cwl.DockerRequirement(dockerPull=dockerpull))
-        command = task.command
-        cwl_command_str = ""
-
-        wdl_command_part_1 = command.parts[0]
-        command_1 = textwrap.dedent(wdl_command_part_1)
-        command_1_splitted_p1, command_1_splitted_p2 = command_1.split("$")
-        command_1 = command_1_splitted_p1 + "\\$" + command_1_splitted_p2
-        cwl_command_str += command_1
-        wdl_command_part_2 = command.parts[1]  # This is a wdl.Expr.placeholder object
-        command_2_expr = wdl_command_part_2.expr.expr.name
-        cwl_command_str += "$(inputs." + command_2_expr + " )"
-        wdl_command_part_3 = command.parts[2]
-        command_3 = textwrap.dedent(wdl_command_part_3)
-        cwl_command_str += command_3
-        wdl_command_part_4 = command.parts[3]
-
-        (
-            command_4_arg_name,
-            command_4_input_value,
-        ) = wdl_command_part_4.expr.arguments  # This is a wdl.Expr.apply object
-        command_4_arg_name_value = command_4_arg_name.literal.value
-        command_4_input_value_name = command_4_input_value.expr.name
-
-        # Since command_4_arg_value.expr.referee.type.optional == True
-        cwl_command_str += (
-            "$(inputs."
-            + command_4_input_value_name
-            + ' === null ? "" : '
-            + f'"{command_4_arg_name_value}"'
-            + " inputs."
-            + command_4_input_value_name
-            + " )"
-        )
-        wdl_command_part_5 = command.parts[4]
-        command_5 = textwrap.dedent(wdl_command_part_5)
-        cwl_command_str += command_5
-        wdl_command_part_6 = command.parts[5]
-
-        (
-            command_6_arg_name,
-            command_6_input_value,
-        ) = wdl_command_part_6.expr.arguments  # This is a wdl.Expr.apply object
-        command_6_arg_name_value = command_6_arg_name.literal.value
-        command_6_input_value_name = command_6_input_value.expr.name
-
-        # Since command_6_arg_value.expr.referee.type.optional == True
-        cwl_command_str += (
-            "$(inputs."
-            + command_6_input_value_name
-            + ' === null ? "" : '
-            + f'"{command_6_arg_name_value}"'
-            + " inputs."
-            + command_6_input_value_name
-            + " )"
-        )
-
-        wdl_command_part_7 = command.parts[6]
-        command_7 = textwrap.dedent(wdl_command_part_7)
-        cwl_command_str += command_7
-
-        wdl_command_part_8 = command.parts[7]
-        (
-            command_8_arg_name,
-            command_8_input_value,
-        ) = wdl_command_part_8.expr.arguments  # This is a wdl.Expr.apply object
-        command_8_arg_name_value = command_8_arg_name.literal.value
-        command_8_input_value_name = command_8_input_value.expr.name
-
-        # Since command_4_arg_value.expr.referee.type.optional == True
-        cwl_command_str += (
-            "$(inputs."
-            + command_8_input_value_name
-            + ' === null ? "" : '
-            + f'"{command_8_arg_name_value}"'
-            + " inputs."
-            + command_8_input_value_name
-            + " )"
-        )
-
-        wdl_command_part_9 = command.parts[8]
-        command_9 = textwrap.dedent(wdl_command_part_9)
-        cwl_command_str += command_9
-        wdl_command_part_10 = command.parts[9]
-
-        # Since wdl_command_part_10.options = {'true': '--best', 'false': '""'}
-        command_10_expr = wdl_command_part_10.expr.expr.name
-        cwl_command_str += (
-            "$(inputs."
-            + command_10_expr
-            + " ? "
-            + '"{true_value}" : "{false_value}")'.format(
-                true_value=wdl_command_part_10.options["true"],
-                false_value=wdl_command_part_10.options["false"],
-            )
-            + ")"
-        )
-        wdl_command_part_11 = command.parts[10]
-        command_11 = textwrap.dedent(wdl_command_part_11)
-        cwl_command_str += command_11
-        wdl_command_part_12 = command.parts[11]
-        command_12_expr = wdl_command_part_12.expr.expr.name
-        # Since wdl_command_part_12.options = {'true': '--best', 'false': '""'}
-        cwl_command_str += (
-            "$(inputs."
-            + command_12_expr
-            + " ? "
-            + '"{true_value}" : "{false_value}")'.format(
-                true_value=wdl_command_part_12.options["true"],
-                false_value=wdl_command_part_12.options["false"],
-            )
-            + ")"
-        )
-        wdl_command_part_13 = command.parts[12]
-        command_13 = textwrap.dedent(wdl_command_part_13)
-        cwl_command_str += command_13
-        wdl_command_part_14 = command.parts[13]
-        command_14_expr = wdl_command_part_14.expr.expr.name
-        # Since wdl_command_part_14.options = {'true': '--best', 'false': '""
-        cwl_command_str += (
-            "$(inputs."
-            + command_14_expr
-            + " ? "
-            + '"{true_value}" : "{false_value}")'.format(
-                true_value=wdl_command_part_14.options["true"],
-                false_value=wdl_command_part_14.options["false"],
-            )
-            + ")"
-        )
-        wdl_command_part_15 = command.parts[14]
-        command_15 = textwrap.dedent(wdl_command_part_15)
-        cwl_command_str += command_15
-        wdl_command_part_16 = command.parts[15]
-
-        (
-            command_16_arg_name,
-            command_16_input_value,
-        ) = wdl_command_part_16.expr.arguments  # This is a wdl.Expr.apply object
-        command_16_arg_name_value = command_16_arg_name.literal.value
-        command_16_input_value_name = command_16_input_value.expr.name
-
-        # Since command_4_arg_value.expr.referee.type.optional == True
-        cwl_command_str += (
-            "$(inputs."
-            + command_16_input_value_name
-            + ' === null ? "" : '
-            + f'"{command_16_arg_name_value}"'
-            + " inputs."
-            + command_16_input_value_name
-            + " )"
-        )
-
-        wdl_command_part_17 = command.parts[16]
-        command_17 = textwrap.dedent(wdl_command_part_17)
-        cwl_command_str += command_17
-        wdl_command_part_18 = command.parts[17]
-
-        (
-            command_18_arg_name,
-            command_18_input_value,
-        ) = wdl_command_part_18.expr.arguments  # This is a wdl.Expr.apply object
-        command_18_arg_name_value = command_18_arg_name.literal.value
-        command_18_input_value_name = command_18_input_value.expr.name
-
-        # Since command_4_arg_value.expr.referee.type.optional == True
-        cwl_command_str += (
-            "$(inputs."
-            + command_18_input_value_name
-            + ' === null ? "" : '
-            + f'"{command_18_arg_name_value}"'
-            + " inputs."
-            + command_18_input_value_name
-            + " )"
-        )
-
-        # Special cases present...the false_valaue should bome before the true value
-        wdl_command_part_19 = command.parts[18]
-        command_19_expr = wdl_command_part_19.expr.arguments[0].expr.referee.name
-        # Since wdl_command_part_14.options = {'true': '--best', 'false': '""
-        cwl_command_str += (
-            "$(inputs."
-            + command_19_expr
-            + " ? "
-            + '"{false_value}" : "{true_value}")'.format(
-                true_value=wdl_command_part_19.options["true"],
-                false_value=wdl_command_part_19.options["false"],
-            )
-        )
-
-        wdl_command_part_20 = command.parts[19]
-        command_20 = textwrap.dedent(wdl_command_part_20)
-        cwl_command_str += command_20
-
-        wdl_command_part_21 = command.parts[20]
-        wdl_command_part_21_expr = wdl_command_part_21
-        wdl_command_part_21_func_name = wdl_command_part_21_expr.expr.function_name
-        wdl_command_part_21_arg = wdl_command_part_21_expr.expr.arguments
-        (
-            wdl_command_part_21_arg_1,
-            wdl_command_part_21_arg_2,
-            wdl_command_part_21_arg_3,
-        ) = wdl_command_part_21_arg
-
-        # since function_name is sub
-        (
-            wdl_command_part_21_arg_1_input_name,
-            wdl_command_part_21_arg_1_index,
-        ) = wdl_command_part_21_arg_1.arguments
-        command_21 = (
-            "$(inputs."
-            + wdl_command_part_21_arg_1_input_name.expr.name
-            + f"[{wdl_command_part_21_arg_1_index.value}]"
-            + f'.replace( "{wdl_command_part_21_arg_2.literal.value}", "{wdl_command_part_21_arg_3.literal.value}") )'
-        )
-        cwl_command_str += command_21
-
-        wdl_command_part_22 = command.parts[21]
-        command_22 = textwrap.dedent(wdl_command_part_22)
-        cwl_command_str += command_22
-
-        wdl_command_part_23 = command.parts[22]
-        wdl_command_part_23_input_name = wdl_command_part_23.expr.expr.name
-        wdl_command_part_23_seperator = wdl_command_part_23.options["sep"]
-        command_23 = (
-            f"$(inputs.{wdl_command_part_23_input_name}.map("
-            + 'function(el) {return el.path}).join("'
-            + wdl_command_part_23_seperator
-            + '"))'
-        )
-        cwl_command_str += command_23
-
-        wdl_command_part_24 = command.parts[23]
-        command_24 = textwrap.dedent(wdl_command_part_24)
-        cwl_command_str += command_24
-
-        wdl_command_part_25 = command.parts[24]
-        cwl_command_str += "$(inputs." + wdl_command_part_25.expr.expr.name + ") "
-
-        wdl_command_part_26 = command.parts[25]
-        command_26 = textwrap.dedent(wdl_command_part_26)
-        cwl_command_str += command_26
-
-        wdl_command_part_27 = command.parts[26]
-        cwl_command_str += "$(inputs." + wdl_command_part_27.expr.expr.name + ") "
-
-        wdl_command_part_28 = command.parts[27]
-        command_28 = textwrap.dedent(wdl_command_part_28)
-        cwl_command_str += command_28
-
-        requirements.append(
-            cwl.InitialWorkDirRequirement(
-                listing=[cwl.Dirent(entry=cwl_command_str, entryname="example.sh")]
-            )
-        )
-        requirements.append(cwl.InlineJavascriptRequirement())
-        requirements.append(cwl.NetworkAccess(networkAccess=True))
-
-        wdl_runtime_cpu = task.runtime["cpu"].expr.name
-        ram_min = f"$(inputs.{wdl_runtime_cpu})"
-        requirements.append(
-            cwl.ResourceRequirement(
-                ramMin=ram_min,
-            )
-        )
-        # Resulting cwl output
-        base_command = ["bash", "example.sh"]
-
-        cat_tool = cwl.CommandLineTool(
-            id=task.name,
-            inputs=cwl_inputs,
-            requirements=requirements,
-            outputs=cwl_outputs,
-            cwlVersion="v1.2",
-            baseCommand=base_command,
-        )
-
-        yaml = YAML()
-        yaml.default_flow_style = False
-        yaml.indent = 4
-        yaml.block_seq_indent = 2
-        result_stream = StringIO()
-        cwl_result = cat_tool.save()
-        scalarstring.walk_tree(cwl_result)
-        yaml.dump(cwl_result, result_stream)
-        yaml.dump(cwl_result, sys.stdout)
-
-        return result_stream.getvalue()
-
-    def main() -> None:
     # write to a file in oop_cwl_files
-        if args.output:
-            with open(args.output, "w") as result:
-                result.write(str(convert(args.workflow)))
+    if args.output:
+        with open(args.output, "w") as result:
+            result.write(str(convert(args.workflow)))
+
+
+if __name__ == "__main__":
+
+    main()
 
     # try:
     #     converted = Converter.load_wdl_tree("wdl2cwl/tests/wdl_files/bowtie_1.wdl")

--- a/wdl2cwl/main_oop.py
+++ b/wdl2cwl/main_oop.py
@@ -11,54 +11,541 @@ from ruamel.yaml import scalarstring
 from ruamel.yaml.main import YAML
 
 
-# WDL-CWL Type Mappings
-wdl_type = {
-    "Array[String]": "string[]",
-    "String": "string",
-    "File": "File",
-    "Int": "int",
-    "Float": "float",
-    "Boolean": "boolean",
-}
+# # WDL-CWL Type Mappings
+# wdl_type = {
+#     "Array[String]": "string[]",
+#     "String": "string",
+#     "File": "File",
+#     "Int": "int",
+#     "Float": "float",
+#     "Boolean": "boolean",
+# }
 
 
-class Converter:
-    @staticmethod
-    def load_wdl_tree(doc: str):
-        wdl_path = os.path.relpath(doc)
+# class Converter:
+#     @staticmethod
+#     def load_wdl_tree(doc: str):
+#         wdl_path = os.path.relpath(doc)
+#         doc_tree = WDL.load(wdl_path)
+
+#         parser = Converter()
+
+#         if doc_tree.workflow:
+#             return parser.load_wdl_objects(doc_tree.workflow)
+
+#         tasks = []
+#         for task in doc_tree.tasks:
+#             tasks.append(parser.load_wdl_objects(task))
+
+#         return tasks[0]
+
+#     def load_wdl_objects(self, obj: WDL.SourceNode):
+#         if isinstance(obj, WDL.Task):
+#             return self.load_wdl_task(obj)
+#         elif isinstance(obj, WDL.Workflow):
+#             return self.load_wdl_workflow(obj)
+
+#     def load_wdl_workflow(self, obj: WDL.Workflow):
+#         print(f"Workflow {obj.name} loaded")
+
+#     def load_wdl_task(self, obj: WDL.Task):
+#         runtime = obj.runtime
+
+#         cwl_inputs = self.get_cwl_inputs(obj.inputs)
+#         base_command = ["bash", "example.sh"]
+
+#         cat_tool = cwl.CommandLineTool(
+#             id=obj.name,
+#             inputs=cwl_inputs,
+#             requirements=None,
+#             outputs=[],
+#             cwlVersion="v1.2",
+#             baseCommand=base_command,
+#         )
+
+#         yaml = YAML()
+#         yaml.default_flow_style = False
+#         yaml.indent = 4
+#         yaml.block_seq_indent = 2
+#         result_stream = StringIO()
+#         cwl_result = cat_tool.save()
+#         scalarstring.walk_tree(cwl_result)
+#         yaml.dump(cwl_result, result_stream)
+#         yaml.dump(cwl_result, sys.stdout)
+
+#         return result_stream.getvalue()
+
+#     def get_cwl_inputs(self, wdl_inputs: List[str]):
+#         inputs = []
+
+#         for wdl_input in wdl_inputs:
+#             input_name = wdl_input.name
+#             input_value = None
+
+#             if isinstance(wdl_input.type, WDL.Type.Array):
+#                 input_type = "File"
+#                 type_of = [cwl.CommandInputArraySchema(items=input_type, type="array")]
+#             elif isinstance(wdl_input.type, WDL.Type.String):
+#                 type_of = "string"
+#             elif isinstance(wdl_input.type, WDL.Type.Boolean):
+#                 type_of = "boolean"
+#             elif isinstance(wdl_input.type, WDL.Type.Int):
+#                 type_of = "int"
+#             else:
+#                 type_of = "unknown type"
+
+#             if wdl_input.type.optional:
+#                 type_of = [type_of, "null"]
+
+#             if wdl_input.expr is not None:
+#                 input_value = wdl_input.expr.literal.value
+
+#             inputs.append(
+#                 cwl.CommandInputParameter(
+#                     id=input_name, type=type_of, default=input_value
+#                 )
+#             )
+
+#         return inputs
+
+#     def translate_command(self, expr: WDL.Expr.Base, inputs: List[str]):
+
+#         if expr is None:
+#             return None
+
+#         if isinstance(expr, WDL.Expr.Array):
+#             return [self.translate_expr(e) for e in expr.items]
+
+#         if isinstance(expr, WDL.Expr.String):
+#             return self.translate_command_string(expr)
+#         elif isinstance(expr, (WDL.Expr.Int, WDL.Expr.Boolean, WDL.Expr.Float)):
+#             return self.literal.value
+#         if isinstance(expr, WDL.Expr.Placeholder):
+#             return self.translate_expr(expr.expr)
+
+#     def translate_command_string(self, string: WDL.Expr.String):
+#         # print("this is the literal", string.literal)
+#         # if string.literal is not None:
+#         #     return str(string.literal).lstrip("').rstrip('"')
+
+#         # elements = {}
+#         # counter = 1
+#         # _format = str(string).lstrip('"').rstrip('"')
+#         # print("from _format", _format)
+
+#         # for placeholder in string.children:
+
+#         #     print(placeholder)
+#         pass
+
+
+if __name__ == "__main__":
+    import sys
+    import argparse
+
+    # Command-line parsing.
+    parser = argparse.ArgumentParser()
+    parser.add_argument("workflow", help="Path to WDL workflow")
+    parser.add_argument("-o", "--output", help="Name of resultant CWL file")
+    args = parser.parse_args()
+
+    def convert(path: str) -> str:
+        wdl_path = path
         doc_tree = WDL.load(wdl_path)
+        task = doc_tree.tasks[0]
+        inputs = task.inputs
+        wdl_first_input = inputs[0]
 
-        parser = Converter()
+        cwl_inputs: List[cwl.CommandInputParameter] = []
 
-        if doc_tree.workflow:
-            return parser.load_wdl_objects(doc_tree.workflow)
+        # add a function to return the cwl type from wdl_type using isinstance
 
-        tasks = []
-        for task in doc_tree.tasks:
-            tasks.append(parser.load_wdl_objects(task))
+        cwl_inputs.append(
+            cwl.CommandInputParameter(
+                id=wdl_first_input.name,
+                type=[cwl.CommandInputArraySchema(items="File", type="array")],
+            )
+        )
+        wdl_second_input = inputs[1]
+        cwl_inputs.append(
+            cwl.CommandInputParameter(
+                id=wdl_second_input.name,
+                type="string",
+                default=wdl_second_input.expr.literal.value,
+            )
+        )
+        wdl_third_input = inputs[2]
+        cwl_inputs.append(
+            cwl.CommandInputParameter(
+                id=wdl_third_input.name,
+                type=[cwl.CommandInputArraySchema(items="File", type="array")],
+            )
+        )
+        wdl_fourth_input = inputs[3]
+        cwl_inputs.append(
+            cwl.CommandInputParameter(
+                id=wdl_fourth_input.name,
+                type="boolean",
+                default=wdl_fourth_input.expr.literal.value,
+            )
+        )
+        wdl_fifth_input = inputs[4]
+        cwl_inputs.append(
+            cwl.CommandInputParameter(
+                id=wdl_fifth_input.name,
+                type="boolean",
+                default=wdl_fifth_input.expr.literal.value,
+            )
+        )
+        wdl_sixth_input = inputs[5]
+        cwl_inputs.append(
+            cwl.CommandInputParameter(
+                id=wdl_sixth_input.name,
+                type="boolean",
+                default=wdl_sixth_input.expr.literal.value,
+            )
+        )
+        wdl_seventh_input = inputs[6]
+        cwl_inputs.append(
+            cwl.CommandInputParameter(
+                id=wdl_seventh_input.name, type=["int", "null"], default=None
+            )
+        )
+        wdl_eight_input = inputs[7]
+        # since wdl_eight_input.type.optional == True then we return an array with null appended
+        cwl_inputs.append(
+            cwl.CommandInputParameter(
+                id=wdl_eight_input.name, type=["int", "null"], default=None
+            )
+        )
+        wdl_nineth_input = inputs[8]
+        cwl_inputs.append(
+            cwl.CommandInputParameter(
+                id=wdl_nineth_input.name, type=["int", "null"], default=None
+            )
+        )
+        wdl_tenth_input = inputs[9]
+        cwl_inputs.append(
+            cwl.CommandInputParameter(
+                id=wdl_tenth_input.name, type=["string", "null"], default=None
+            )
+        )
+        wdl_eleventh_input = inputs[10]
+        cwl_inputs.append(
+            cwl.CommandInputParameter(
+                id=wdl_eleventh_input.name,
+                type="string",
+                default=wdl_eleventh_input.expr.literal.value,
+            )
+        )
+        wdl_twelveth_input = inputs[11]
+        cwl_inputs.append(
+            cwl.CommandInputParameter(
+                id=wdl_twelveth_input.name,
+                type="int",
+                default=wdl_twelveth_input.expr.literal.value,
+            )
+        )
+        wdl_thirteenth_input = inputs[12]
+        cwl_inputs.append(
+            cwl.CommandInputParameter(
+                id=wdl_thirteenth_input.name,
+                type="string",
+                default=wdl_thirteenth_input.expr.literal.value,
+            )
+        )
 
-        return tasks[0]
+        wdl_outputs = task.outputs
+        cwl_outputs = []
+        wdl_first_output = wdl_outputs[0]
 
-    def load_wdl_objects(self, obj: WDL.SourceNode):
-        if isinstance(obj, WDL.Task):
-            return self.load_wdl_task(obj)
-        elif isinstance(obj, WDL.Workflow):
-            return self.load_wdl_workflow(obj)
+        cwl_outputs.append(
+            cwl.CommandOutputParameter(
+                id=wdl_first_output.name,
+                type="File",
+                outputBinding=cwl.CommandOutputBinding(
+                    glob="$(inputs.{outputpath})".format(
+                        outputpath=wdl_first_output.expr.expr.name
+                    )
+                ),
+            )
+        )
 
-    def load_wdl_workflow(self, obj: WDL.Workflow):
-        print(f"Workflow {obj.name} loaded")
+        requirements: List[cwl.ProcessRequirement] = []
 
-    def load_wdl_task(self, obj: WDL.Task):
-        runtime = obj.runtime
+        dockerpull = task.runtime["docker"].expr.referee.expr.literal.value
+        requirements.append(cwl.DockerRequirement(dockerPull=dockerpull))
+        command = task.command
+        cwl_command_str = ""
 
-        cwl_inputs = self.get_cwl_inputs(obj.inputs)
+        wdl_command_part_1 = command.parts[0]
+        command_1 = textwrap.dedent(wdl_command_part_1)
+        command_1_splitted_p1, command_1_splitted_p2 = command_1.split("$")
+        command_1 = command_1_splitted_p1 + "\\$" + command_1_splitted_p2
+        cwl_command_str += command_1
+        wdl_command_part_2 = command.parts[1]  # This is a wdl.Expr.placeholder object
+        command_2_expr = wdl_command_part_2.expr.expr.name
+        cwl_command_str += "$(inputs." + command_2_expr + " )"
+        wdl_command_part_3 = command.parts[2]
+        command_3 = textwrap.dedent(wdl_command_part_3)
+        cwl_command_str += command_3
+        wdl_command_part_4 = command.parts[3]
+
+        (
+            command_4_arg_name,
+            command_4_input_value,
+        ) = wdl_command_part_4.expr.arguments  # This is a wdl.Expr.apply object
+        command_4_arg_name_value = command_4_arg_name.literal.value
+        command_4_input_value_name = command_4_input_value.expr.name
+
+        # Since command_4_arg_value.expr.referee.type.optional == True
+        cwl_command_str += (
+            "$(inputs."
+            + command_4_input_value_name
+            + ' === null ? "" : '
+            + f'"{command_4_arg_name_value}"'
+            + " inputs."
+            + command_4_input_value_name
+            + " )"
+        )
+        wdl_command_part_5 = command.parts[4]
+        command_5 = textwrap.dedent(wdl_command_part_5)
+        cwl_command_str += command_5
+        wdl_command_part_6 = command.parts[5]
+
+        (
+            command_6_arg_name,
+            command_6_input_value,
+        ) = wdl_command_part_6.expr.arguments  # This is a wdl.Expr.apply object
+        command_6_arg_name_value = command_6_arg_name.literal.value
+        command_6_input_value_name = command_6_input_value.expr.name
+
+        # Since command_6_arg_value.expr.referee.type.optional == True
+        cwl_command_str += (
+            "$(inputs."
+            + command_6_input_value_name
+            + ' === null ? "" : '
+            + f'"{command_6_arg_name_value}"'
+            + " inputs."
+            + command_6_input_value_name
+            + " )"
+        )
+
+        wdl_command_part_7 = command.parts[6]
+        command_7 = textwrap.dedent(wdl_command_part_7)
+        cwl_command_str += command_7
+
+        wdl_command_part_8 = command.parts[7]
+        (
+            command_8_arg_name,
+            command_8_input_value,
+        ) = wdl_command_part_8.expr.arguments  # This is a wdl.Expr.apply object
+        command_8_arg_name_value = command_8_arg_name.literal.value
+        command_8_input_value_name = command_8_input_value.expr.name
+
+        # Since command_4_arg_value.expr.referee.type.optional == True
+        cwl_command_str += (
+            "$(inputs."
+            + command_8_input_value_name
+            + ' === null ? "" : '
+            + f'"{command_8_arg_name_value}"'
+            + " inputs."
+            + command_8_input_value_name
+            + " )"
+        )
+
+        wdl_command_part_9 = command.parts[8]
+        command_9 = textwrap.dedent(wdl_command_part_9)
+        cwl_command_str += command_9
+        wdl_command_part_10 = command.parts[9]
+
+        # Since wdl_command_part_10.options = {'true': '--best', 'false': '""'}
+        command_10_expr = wdl_command_part_10.expr.expr.name
+        cwl_command_str += (
+            "$(inputs."
+            + command_10_expr
+            + " ? "
+            + '"{true_value}" : "{false_value}")'.format(
+                true_value=wdl_command_part_10.options["true"],
+                false_value=wdl_command_part_10.options["false"],
+            )
+            + ")"
+        )
+        wdl_command_part_11 = command.parts[10]
+        command_11 = textwrap.dedent(wdl_command_part_11)
+        cwl_command_str += command_11
+        wdl_command_part_12 = command.parts[11]
+        command_12_expr = wdl_command_part_12.expr.expr.name
+        # Since wdl_command_part_12.options = {'true': '--best', 'false': '""'}
+        cwl_command_str += (
+            "$(inputs."
+            + command_12_expr
+            + " ? "
+            + '"{true_value}" : "{false_value}")'.format(
+                true_value=wdl_command_part_12.options["true"],
+                false_value=wdl_command_part_12.options["false"],
+            )
+            + ")"
+        )
+        wdl_command_part_13 = command.parts[12]
+        command_13 = textwrap.dedent(wdl_command_part_13)
+        cwl_command_str += command_13
+        wdl_command_part_14 = command.parts[13]
+        command_14_expr = wdl_command_part_14.expr.expr.name
+        # Since wdl_command_part_14.options = {'true': '--best', 'false': '""
+        cwl_command_str += (
+            "$(inputs."
+            + command_14_expr
+            + " ? "
+            + '"{true_value}" : "{false_value}")'.format(
+                true_value=wdl_command_part_14.options["true"],
+                false_value=wdl_command_part_14.options["false"],
+            )
+            + ")"
+        )
+        wdl_command_part_15 = command.parts[14]
+        command_15 = textwrap.dedent(wdl_command_part_15)
+        cwl_command_str += command_15
+        wdl_command_part_16 = command.parts[15]
+
+        (
+            command_16_arg_name,
+            command_16_input_value,
+        ) = wdl_command_part_16.expr.arguments  # This is a wdl.Expr.apply object
+        command_16_arg_name_value = command_16_arg_name.literal.value
+        command_16_input_value_name = command_16_input_value.expr.name
+
+        # Since command_4_arg_value.expr.referee.type.optional == True
+        cwl_command_str += (
+            "$(inputs."
+            + command_16_input_value_name
+            + ' === null ? "" : '
+            + f'"{command_16_arg_name_value}"'
+            + " inputs."
+            + command_16_input_value_name
+            + " )"
+        )
+
+        wdl_command_part_17 = command.parts[16]
+        command_17 = textwrap.dedent(wdl_command_part_17)
+        cwl_command_str += command_17
+        wdl_command_part_18 = command.parts[17]
+
+        (
+            command_18_arg_name,
+            command_18_input_value,
+        ) = wdl_command_part_18.expr.arguments  # This is a wdl.Expr.apply object
+        command_18_arg_name_value = command_18_arg_name.literal.value
+        command_18_input_value_name = command_18_input_value.expr.name
+
+        # Since command_4_arg_value.expr.referee.type.optional == True
+        cwl_command_str += (
+            "$(inputs."
+            + command_18_input_value_name
+            + ' === null ? "" : '
+            + f'"{command_18_arg_name_value}"'
+            + " inputs."
+            + command_18_input_value_name
+            + " )"
+        )
+
+        # Special cases present...the false_valaue should bome before the true value
+        wdl_command_part_19 = command.parts[18]
+        command_19_expr = wdl_command_part_19.expr.arguments[0].expr.referee.name
+        # Since wdl_command_part_14.options = {'true': '--best', 'false': '""
+        cwl_command_str += (
+            "$(inputs."
+            + command_19_expr
+            + " ? "
+            + '"{false_value}" : "{true_value}")'.format(
+                true_value=wdl_command_part_19.options["true"],
+                false_value=wdl_command_part_19.options["false"],
+            )
+        )
+
+        wdl_command_part_20 = command.parts[19]
+        command_20 = textwrap.dedent(wdl_command_part_20)
+        cwl_command_str += command_20
+
+        wdl_command_part_21 = command.parts[20]
+        wdl_command_part_21_expr = wdl_command_part_21
+        wdl_command_part_21_func_name = wdl_command_part_21_expr.expr.function_name
+        wdl_command_part_21_arg = wdl_command_part_21_expr.expr.arguments
+        (
+            wdl_command_part_21_arg_1,
+            wdl_command_part_21_arg_2,
+            wdl_command_part_21_arg_3,
+        ) = wdl_command_part_21_arg
+
+        # since function_name is sub
+        (
+            wdl_command_part_21_arg_1_input_name,
+            wdl_command_part_21_arg_1_index,
+        ) = wdl_command_part_21_arg_1.arguments
+        command_21 = (
+            "$(inputs."
+            + wdl_command_part_21_arg_1_input_name.expr.name
+            + f"[{wdl_command_part_21_arg_1_index.value}]"
+            + f'.replace( "{wdl_command_part_21_arg_2.literal.value}", "{wdl_command_part_21_arg_3.literal.value}") )'
+        )
+        cwl_command_str += command_21
+
+        wdl_command_part_22 = command.parts[21]
+        command_22 = textwrap.dedent(wdl_command_part_22)
+        cwl_command_str += command_22
+
+        wdl_command_part_23 = command.parts[22]
+        wdl_command_part_23_input_name = wdl_command_part_23.expr.expr.name
+        wdl_command_part_23_seperator = wdl_command_part_23.options["sep"]
+        command_23 = (
+            f"$(inputs.{wdl_command_part_23_input_name}.map("
+            + 'function(el) {return el.path}).join("'
+            + wdl_command_part_23_seperator
+            + '"))'
+        )
+        cwl_command_str += command_23
+
+        wdl_command_part_24 = command.parts[23]
+        command_24 = textwrap.dedent(wdl_command_part_24)
+        cwl_command_str += command_24
+
+        wdl_command_part_25 = command.parts[24]
+        cwl_command_str += "$(inputs." + wdl_command_part_25.expr.expr.name + ") "
+
+        wdl_command_part_26 = command.parts[25]
+        command_26 = textwrap.dedent(wdl_command_part_26)
+        cwl_command_str += command_26
+
+        wdl_command_part_27 = command.parts[26]
+        cwl_command_str += "$(inputs." + wdl_command_part_27.expr.expr.name + ") "
+
+        wdl_command_part_28 = command.parts[27]
+        command_28 = textwrap.dedent(wdl_command_part_28)
+        cwl_command_str += command_28
+
+        requirements.append(
+            cwl.InitialWorkDirRequirement(
+                listing=[cwl.Dirent(entry=cwl_command_str, entryname="example.sh")]
+            )
+        )
+        requirements.append(cwl.InlineJavascriptRequirement())
+        requirements.append(cwl.NetworkAccess(networkAccess=True))
+
+        wdl_runtime_cpu = task.runtime["cpu"].expr.name
+        ram_min = f"$(inputs.{wdl_runtime_cpu})"
+        requirements.append(
+            cwl.ResourceRequirement(
+                ramMin=ram_min,
+            )
+        )
+        # Resulting cwl output
         base_command = ["bash", "example.sh"]
 
         cat_tool = cwl.CommandLineTool(
-            id=obj.name,
+            id=task.name,
             inputs=cwl_inputs,
-            requirements=None,
-            outputs=[],
+            requirements=requirements,
+            outputs=cwl_outputs,
             cwlVersion="v1.2",
             baseCommand=base_command,
         )
@@ -75,496 +562,11 @@ class Converter:
 
         return result_stream.getvalue()
 
-    def get_cwl_inputs(self, wdl_inputs: List[str]):
-        inputs = []
-
-        for wdl_input in wdl_inputs:
-            input_name = wdl_input.name
-            input_value = None
-
-            if isinstance(wdl_input.type, WDL.Type.Array):
-                input_type = "File"
-                type_of = [cwl.CommandInputArraySchema(items=input_type, type="array")]
-            elif isinstance(wdl_input.type, WDL.Type.String):
-                type_of = "string"
-            elif isinstance(wdl_input.type, WDL.Type.Boolean):
-                type_of = "boolean"
-            elif isinstance(wdl_input.type, WDL.Type.Int):
-                type_of = "int"
-            else:
-                type_of = "unknown type"
-
-            if wdl_input.type.optional:
-                type_of = [type_of, "null"]
-
-            if wdl_input.expr is not None:
-                input_value = wdl_input.expr.literal.value
-
-            inputs.append(
-                cwl.CommandInputParameter(
-                    id=input_name, type=type_of, default=input_value
-                )
-            )
-
-        return inputs
-
-    def translate_command(self, expr: WDL.Expr.Base, inputs: List[str]):
-
-        if expr is None:
-            return None
-
-        if isinstance(expr, WDL.Expr.Array):
-            return [self.translate_expr(e) for e in expr.items]
-
-        if isinstance(expr, WDL.Expr.String):
-            return self.translate_command_string(expr)
-        elif isinstance(expr, (WDL.Expr.Int, WDL.Expr.Boolean, WDL.Expr.Float)):
-            return self.literal.value
-        if isinstance(expr, WDL.Expr.Placeholder):
-            return self.translate_expr(expr.expr)
-
-    def translate_command_string(self, string: WDL.Expr.String):
-        # print("this is the literal", string.literal)
-        # if string.literal is not None:
-        #     return str(string.literal).lstrip("').rstrip('"')
-
-        # elements = {}
-        # counter = 1
-        # _format = str(string).lstrip('"').rstrip('"')
-        # print("from _format", _format)
-
-        # for placeholder in string.children:
-
-        #     print(placeholder)
-        pass
-
-
-if __name__ == "__main__":
-    import sys
-    import argparse
-
-    # Command-line parsing.
-    parser = argparse.ArgumentParser()
-    parser.add_argument("workflow", help="Path to WDL workflow")
-    parser.add_argument("-o", "--output", help="Name of resultant CWL file")
-    args = parser.parse_args()
-
-    wdl_path = args.workflow
-    doc_tree = WDL.load(wdl_path)
-    task = doc_tree.tasks[0]
-    inputs = task.inputs
-    wdl_first_input = inputs[0]
-
-    cwl_inputs: List[cwl.CommandInputParameter] = []
-
-    # add a function to return the cwl type from wdl_type using isinstance
-
-    cwl_inputs.append(
-        cwl.CommandInputParameter(
-            id=wdl_first_input.name,
-            type=[cwl.CommandInputArraySchema(items="File", type="array")],
-        )
-    )
-    wdl_second_input = inputs[1]
-    cwl_inputs.append(
-        cwl.CommandInputParameter(
-            id=wdl_second_input.name,
-            type="string",
-            default=wdl_second_input.expr.literal.value,
-        )
-    )
-    wdl_third_input = inputs[2]
-    cwl_inputs.append(
-        cwl.CommandInputParameter(
-            id=wdl_third_input.name,
-            type=[cwl.CommandInputArraySchema(items="File", type="array")],
-        )
-    )
-    wdl_fourth_input = inputs[3]
-    cwl_inputs.append(
-        cwl.CommandInputParameter(
-            id=wdl_fourth_input.name,
-            type="boolean",
-            default=wdl_fourth_input.expr.literal.value,
-        )
-    )
-    wdl_fifth_input = inputs[4]
-    cwl_inputs.append(
-        cwl.CommandInputParameter(
-            id=wdl_fifth_input.name,
-            type="boolean",
-            default=wdl_fifth_input.expr.literal.value,
-        )
-    )
-    wdl_sixth_input = inputs[5]
-    cwl_inputs.append(
-        cwl.CommandInputParameter(
-            id=wdl_sixth_input.name,
-            type="boolean",
-            default=wdl_sixth_input.expr.literal.value,
-        )
-    )
-    wdl_seventh_input = inputs[6]
-    cwl_inputs.append(
-        cwl.CommandInputParameter(
-            id=wdl_seventh_input.name, type=["int", "null"], default=None
-        )
-    )
-    wdl_eight_input = inputs[7]
-    # since wdl_eight_input.type.optional == True then we return an array with null appended
-    cwl_inputs.append(
-        cwl.CommandInputParameter(
-            id=wdl_eight_input.name, type=["int", "null"], default=None
-        )
-    )
-    wdl_nineth_input = inputs[8]
-    cwl_inputs.append(
-        cwl.CommandInputParameter(
-            id=wdl_nineth_input.name, type=["int", "null"], default=None
-        )
-    )
-    wdl_tenth_input = inputs[9]
-    cwl_inputs.append(
-        cwl.CommandInputParameter(
-            id=wdl_tenth_input.name, type=["string", "null"], default=None
-        )
-    )
-    wdl_eleventh_input = inputs[10]
-    cwl_inputs.append(
-        cwl.CommandInputParameter(
-            id=wdl_eleventh_input.name,
-            type="string",
-            default=wdl_eleventh_input.expr.literal.value,
-        )
-    )
-    wdl_twelveth_input = inputs[11]
-    cwl_inputs.append(
-        cwl.CommandInputParameter(
-            id=wdl_twelveth_input.name,
-            type="int",
-            default=wdl_twelveth_input.expr.literal.value,
-        )
-    )
-    wdl_thirteenth_input = inputs[12]
-    cwl_inputs.append(
-        cwl.CommandInputParameter(
-            id=wdl_thirteenth_input.name,
-            type="string",
-            default=wdl_thirteenth_input.expr.literal.value,
-        )
-    )
-
-    wdl_outputs = task.outputs
-    cwl_outputs = []
-    wdl_first_output = wdl_outputs[0]
-
-    cwl_outputs.append(
-        cwl.CommandOutputParameter(
-            id=wdl_first_output.name,
-            type="File",
-            outputBinding=cwl.CommandOutputBinding(
-                glob="$(inputs.{outputpath})".format(
-                    outputpath=wdl_first_output.expr.expr.name
-                )
-            ),
-        )
-    )
-
-    requirements: List[cwl.ProcessRequirement] = []
-
-    dockerpull = task.runtime["docker"].expr.referee.expr.literal.value
-    requirements.append(cwl.DockerRequirement(dockerPull=dockerpull))
-    command = task.command
-    cwl_command_str = ""
-
-    wdl_command_part_1 = command.parts[0]
-    command_1 = textwrap.dedent(wdl_command_part_1)
-    command_1_splitted_p1, command_1_splitted_p2 = command_1.split("$")
-    command_1 = command_1_splitted_p1 + "\\$" + command_1_splitted_p2
-    cwl_command_str += command_1
-    wdl_command_part_2 = command.parts[1]  # This is a wdl.Expr.placeholder object
-    command_2_expr = wdl_command_part_2.expr.expr.name
-    cwl_command_str += "$(inputs." + command_2_expr + " )"
-    wdl_command_part_3 = command.parts[2]
-    command_3 = textwrap.dedent(wdl_command_part_3)
-    cwl_command_str += command_3
-    wdl_command_part_4 = command.parts[3]
-
-    (
-        command_4_arg_name,
-        command_4_input_value,
-    ) = wdl_command_part_4.expr.arguments  # This is a wdl.Expr.apply object
-    command_4_arg_name_value = command_4_arg_name.literal.value
-    command_4_input_value_name = command_4_input_value.expr.name
-
-    # Since command_4_arg_value.expr.referee.type.optional == True
-    cwl_command_str += (
-        "$(inputs."
-        + command_4_input_value_name
-        + ' === null ? "" : '
-        + f'"{command_4_arg_name_value}"'
-        + " inputs."
-        + command_4_input_value_name
-        + " )"
-    )
-    wdl_command_part_5 = command.parts[4]
-    command_5 = textwrap.dedent(wdl_command_part_5)
-    cwl_command_str += command_5
-    wdl_command_part_6 = command.parts[5]
-
-    (
-        command_6_arg_name,
-        command_6_input_value,
-    ) = wdl_command_part_6.expr.arguments  # This is a wdl.Expr.apply object
-    command_6_arg_name_value = command_6_arg_name.literal.value
-    command_6_input_value_name = command_6_input_value.expr.name
-
-    # Since command_6_arg_value.expr.referee.type.optional == True
-    cwl_command_str += (
-        "$(inputs."
-        + command_6_input_value_name
-        + ' === null ? "" : '
-        + f'"{command_6_arg_name_value}"'
-        + " inputs."
-        + command_6_input_value_name
-        + " )"
-    )
-
-    wdl_command_part_7 = command.parts[6]
-    command_7 = textwrap.dedent(wdl_command_part_7)
-    cwl_command_str += command_7
-
-    wdl_command_part_8 = command.parts[7]
-    (
-        command_8_arg_name,
-        command_8_input_value,
-    ) = wdl_command_part_8.expr.arguments  # This is a wdl.Expr.apply object
-    command_8_arg_name_value = command_8_arg_name.literal.value
-    command_8_input_value_name = command_8_input_value.expr.name
-
-    # Since command_4_arg_value.expr.referee.type.optional == True
-    cwl_command_str += (
-        "$(inputs."
-        + command_8_input_value_name
-        + ' === null ? "" : '
-        + f'"{command_8_arg_name_value}"'
-        + " inputs."
-        + command_8_input_value_name
-        + " )"
-    )
-
-    wdl_command_part_9 = command.parts[8]
-    command_9 = textwrap.dedent(wdl_command_part_9)
-    cwl_command_str += command_9
-    wdl_command_part_10 = command.parts[9]
-
-    # Since wdl_command_part_10.options = {'true': '--best', 'false': '""'}
-    command_10_expr = wdl_command_part_10.expr.expr.name
-    cwl_command_str += (
-        "$(inputs."
-        + command_10_expr
-        + " ? "
-        + '"{true_value}" : "{false_value}")'.format(
-            true_value=wdl_command_part_10.options["true"],
-            false_value=wdl_command_part_10.options["false"],
-        )
-        + ")"
-    )
-    wdl_command_part_11 = command.parts[10]
-    command_11 = textwrap.dedent(wdl_command_part_11)
-    cwl_command_str += command_11
-    wdl_command_part_12 = command.parts[11]
-    command_12_expr = wdl_command_part_12.expr.expr.name
-    # Since wdl_command_part_12.options = {'true': '--best', 'false': '""'}
-    cwl_command_str += (
-        "$(inputs."
-        + command_12_expr
-        + " ? "
-        + '"{true_value}" : "{false_value}")'.format(
-            true_value=wdl_command_part_12.options["true"],
-            false_value=wdl_command_part_12.options["false"],
-        )
-        + ")"
-    )
-    wdl_command_part_13 = command.parts[12]
-    command_13 = textwrap.dedent(wdl_command_part_13)
-    cwl_command_str += command_13
-    wdl_command_part_14 = command.parts[13]
-    command_14_expr = wdl_command_part_14.expr.expr.name
-    # Since wdl_command_part_14.options = {'true': '--best', 'false': '""
-    cwl_command_str += (
-        "$(inputs."
-        + command_14_expr
-        + " ? "
-        + '"{true_value}" : "{false_value}")'.format(
-            true_value=wdl_command_part_14.options["true"],
-            false_value=wdl_command_part_14.options["false"],
-        )
-        + ")"
-    )
-    wdl_command_part_15 = command.parts[14]
-    command_15 = textwrap.dedent(wdl_command_part_15)
-    cwl_command_str += command_15
-    wdl_command_part_16 = command.parts[15]
-
-    (
-        command_16_arg_name,
-        command_16_input_value,
-    ) = wdl_command_part_16.expr.arguments  # This is a wdl.Expr.apply object
-    command_16_arg_name_value = command_16_arg_name.literal.value
-    command_16_input_value_name = command_16_input_value.expr.name
-
-    # Since command_4_arg_value.expr.referee.type.optional == True
-    cwl_command_str += (
-        "$(inputs."
-        + command_16_input_value_name
-        + ' === null ? "" : '
-        + f'"{command_16_arg_name_value}"'
-        + " inputs."
-        + command_16_input_value_name
-        + " )"
-    )
-
-    wdl_command_part_17 = command.parts[16]
-    command_17 = textwrap.dedent(wdl_command_part_17)
-    cwl_command_str += command_17
-    wdl_command_part_18 = command.parts[17]
-
-    (
-        command_18_arg_name,
-        command_18_input_value,
-    ) = wdl_command_part_18.expr.arguments  # This is a wdl.Expr.apply object
-    command_18_arg_name_value = command_18_arg_name.literal.value
-    command_18_input_value_name = command_18_input_value.expr.name
-
-    # Since command_4_arg_value.expr.referee.type.optional == True
-    cwl_command_str += (
-        "$(inputs."
-        + command_18_input_value_name
-        + ' === null ? "" : '
-        + f'"{command_18_arg_name_value}"'
-        + " inputs."
-        + command_18_input_value_name
-        + " )"
-    )
-
-    # Special cases present...the false_valaue should bome before the true value
-    wdl_command_part_19 = command.parts[18]
-    command_19_expr = wdl_command_part_19.expr.arguments[0].expr.referee.name
-    # Since wdl_command_part_14.options = {'true': '--best', 'false': '""
-    cwl_command_str += (
-        "$(inputs."
-        + command_19_expr
-        + " ? "
-        + '"{false_value}" : "{true_value}")'.format(
-            true_value=wdl_command_part_19.options["true"],
-            false_value=wdl_command_part_19.options["false"],
-        )
-    )
-
-    wdl_command_part_20 = command.parts[19]
-    command_20 = textwrap.dedent(wdl_command_part_20)
-    cwl_command_str += command_20
-
-    wdl_command_part_21 = command.parts[20]
-    wdl_command_part_21_expr = wdl_command_part_21
-    wdl_command_part_21_func_name = wdl_command_part_21_expr.expr.function_name
-    wdl_command_part_21_arg = wdl_command_part_21_expr.expr.arguments
-    (
-        wdl_command_part_21_arg_1,
-        wdl_command_part_21_arg_2,
-        wdl_command_part_21_arg_3,
-    ) = wdl_command_part_21_arg
-
-    # since function_name is sub
-    (
-        wdl_command_part_21_arg_1_input_name,
-        wdl_command_part_21_arg_1_index,
-    ) = wdl_command_part_21_arg_1.arguments
-    command_21 = (
-        "$(inputs."
-        + wdl_command_part_21_arg_1_input_name.expr.name
-        + f"[{wdl_command_part_21_arg_1_index.value}]"
-        + f'.replace( "{wdl_command_part_21_arg_2.literal.value}", "{wdl_command_part_21_arg_3.literal.value}") )'
-    )
-    cwl_command_str += command_21
-
-    wdl_command_part_22 = command.parts[21]
-    command_22 = textwrap.dedent(wdl_command_part_22)
-    cwl_command_str += command_22
-
-    wdl_command_part_23 = command.parts[22]
-    wdl_command_part_23_input_name = wdl_command_part_23.expr.expr.name
-    wdl_command_part_23_seperator = wdl_command_part_23.options["sep"]
-    command_23 = (
-        f"$(inputs.{wdl_command_part_23_input_name}.map("
-        + 'function(el) {return el.path}).join("'
-        + wdl_command_part_23_seperator
-        + '"))'
-    )
-    cwl_command_str += command_23
-
-    wdl_command_part_24 = command.parts[23]
-    command_24 = textwrap.dedent(wdl_command_part_24)
-    cwl_command_str += command_24
-
-    wdl_command_part_25 = command.parts[24]
-    cwl_command_str += "$(inputs." + wdl_command_part_25.expr.expr.name + ") "
-
-    wdl_command_part_26 = command.parts[25]
-    command_26 = textwrap.dedent(wdl_command_part_26)
-    cwl_command_str += command_26
-
-    wdl_command_part_27 = command.parts[26]
-    cwl_command_str += "$(inputs." + wdl_command_part_27.expr.expr.name + ") "
-
-    wdl_command_part_28 = command.parts[27]
-    command_28 = textwrap.dedent(wdl_command_part_28)
-    cwl_command_str += command_28
-
-    requirements.append(
-        cwl.InitialWorkDirRequirement(
-            listing=[cwl.Dirent(entry=cwl_command_str, entryname="example.sh")]
-        )
-    )
-    requirements.append(cwl.InlineJavascriptRequirement())
-    requirements.append(cwl.NetworkAccess(networkAccess=True))
-
-    wdl_runtime_cpu = task.runtime["cpu"].expr.name
-    ram_min = f"$(inputs.{wdl_runtime_cpu})"
-    requirements.append(
-        cwl.ResourceRequirement(
-            ramMin=ram_min,
-        )
-    )
-    # Resulting cwl output
-    base_command = ["bash", "example.sh"]
-
-    cat_tool = cwl.CommandLineTool(
-        id=task.name,
-        inputs=cwl_inputs,
-        requirements=requirements,
-        outputs=cwl_outputs,
-        cwlVersion="v1.2",
-        baseCommand=base_command,
-    )
-
-    yaml = YAML()
-    yaml.default_flow_style = False
-    yaml.indent = 4
-    yaml.block_seq_indent = 2
-    result_stream = StringIO()
-    cwl_result = cat_tool.save()
-    scalarstring.walk_tree(cwl_result)
-    yaml.dump(cwl_result, result_stream)
-    yaml.dump(cwl_result, sys.stdout)
-
-    result_stream.getvalue()
-
+    def main() -> None:
     # write to a file in oop_cwl_files
-    if args.output:
-        with open(args.output, "w") as result:
-            result.write(result_stream.getvalue())
+        if args.output:
+            with open(args.output, "w") as result:
+                result.write(str(convert(args.workflow)))
 
     # try:
     #     converted = Converter.load_wdl_tree("wdl2cwl/tests/wdl_files/bowtie_1.wdl")

--- a/wdl2cwl/main_oop.py
+++ b/wdl2cwl/main_oop.py
@@ -1,6 +1,6 @@
 import os
 from typing import List, Union, Optional, Callable
-import WDL # type: ignore
+import WDL  # type: ignore[import]
 import cwl_utils.parser.cwl_v1_2 as cwl
 
 from io import StringIO

--- a/wdl2cwl/main_oop.py
+++ b/wdl2cwl/main_oop.py
@@ -11,6 +11,16 @@ from ruamel.yaml import scalarstring
 from ruamel.yaml.main import YAML
 
 
+# WDL-CWL Type Mappings
+wdl_type = {
+    "Array[String]": "string[]",
+    "String": "string",
+    "File": "File",
+    "Int": "int",
+    "Float": "float",
+    "Boolean": "boolean",
+}
+
 
 class Converter:
 
@@ -74,18 +84,17 @@ class Converter:
             input_name = wdl_input.name
             input_value = None
 
-            if isinstance(wdl_input, WDL.Type.Array):
+            if isinstance(wdl_input.type, WDL.Type.Array):
                 input_type = 'File'
                 type_of = [cwl.CommandInputArraySchema(items=input_type, type="array")]
-            elif isinstance(wdl_input, WDL.Type.String):
+            elif isinstance(wdl_input.type, WDL.Type.String):
                 type_of = "string"
-            elif isinstance(wdl_input, WDL.Type.Boolean):
+            elif isinstance(wdl_input.type, WDL.Type.Boolean):
                 type_of = "boolean"
-            elif isinstance(wdl_input, WDL.Type.Int):
+            elif isinstance(wdl_input.type, WDL.Type.Int):
                 type_of = "int"
             else:
-                print(wdl_input.type)
-                type_of = ""
+                type_of = "unknown type"
 
 
             if wdl_input.type.optional: type_of = [type_of, "null"]
@@ -137,6 +146,7 @@ if __name__ == '__main__':
     import sys
     import argparse
     
+
     
     # Command-line parsing.
     parser = argparse.ArgumentParser()
@@ -144,14 +154,157 @@ if __name__ == '__main__':
 
     # args = parser.parse_args()
 
+    wdl_path = "wdl2cwl/tests/wdl_files/bowtie_1.wdl"
+    doc_tree = WDL.load(wdl_path)
+    task = doc_tree.tasks[0]
+    inputs = task.inputs
+    wdl_first_input = inputs[0]
 
-    try:
-        converted = Converter.load_wdl_tree("wdl2cwl/tests/wdl_files/bowtie_1.wdl")
-        # converted = Converter.load_wdl_tree(args.workflow)
-    except WDL.Error.SyntaxError as err:
-        print(err)
-    except WDL.Error.ValidationError as err:
-        print(err)
-    except WDL.Error.MultipleValidationErrors as err:
-        for error in err.exceptions:
-            print(error)
+    cwl_inputs: List[cwl.CommandInputParameter] = []
+
+    # add a function to return the cwl type from wdl_type using isinstance
+
+    cwl_inputs.append(
+                cwl.CommandInputParameter(
+                    id=wdl_first_input.name,
+                    type=[cwl.CommandInputArraySchema(items="File", type="array")],
+                )
+            )
+    wdl_second_input = inputs[1]
+    cwl_inputs.append(
+                cwl.CommandInputParameter(
+                    id=wdl_second_input.name,
+                    type="string", default=wdl_second_input.expr.literal.value
+                )
+            )
+    wdl_third_input = inputs[2]
+    cwl_inputs.append(
+                cwl.CommandInputParameter(
+                    id=wdl_third_input.name,
+                    type=[cwl.CommandInputArraySchema(items="File", type="array")],
+                )
+            )
+    wdl_fourth_input = inputs[3]
+    cwl_inputs.append(
+                cwl.CommandInputParameter(
+                    id=wdl_fourth_input.name,
+                    type="boolean", default=wdl_fourth_input.expr.literal.value
+                )
+            )
+    wdl_fifth_input = inputs[4]
+    cwl_inputs.append(
+                cwl.CommandInputParameter(
+                    id=wdl_fifth_input.name,
+                    type="boolean", default=wdl_fifth_input.expr.literal.value
+                )
+            )
+    wdl_sixth_input = inputs[5]
+    cwl_inputs.append(
+                cwl.CommandInputParameter(
+                    id=wdl_sixth_input.name,
+                    type="boolean", default=wdl_sixth_input.expr.literal.value
+                )
+            )
+    wdl_seventh_input = inputs[6]
+    cwl_inputs.append(
+                cwl.CommandInputParameter(
+                    id=wdl_seventh_input.name,
+                    type=["int", "null"], default=None
+                )
+            )
+    wdl_eight_input = inputs[7]
+    # since wdl_eight_input.type.optional == True then we return an array with null appended
+    cwl_inputs.append(
+                cwl.CommandInputParameter(
+                    id=wdl_eight_input.name,
+                    type=["int", "null"], default=None
+                )
+            )
+    wdl_nineth_input = inputs[8]
+    cwl_inputs.append(
+                cwl.CommandInputParameter(
+                    id=wdl_nineth_input.name,
+                    type=["int", "null"], default=None
+                )
+            )
+    wdl_tenth_input = inputs[9]
+    cwl_inputs.append(
+                cwl.CommandInputParameter(
+                    id=wdl_tenth_input.name,
+                    type=["string", "null"], default=None
+                )
+            )
+    wdl_eleventh_input = inputs[10]
+    cwl_inputs.append(
+                cwl.CommandInputParameter(
+                    id=wdl_eleventh_input.name,
+                    type="string", default=wdl_eleventh_input.expr.literal.value
+                )
+            )
+    wdl_twelveth_input = inputs[11]
+    cwl_inputs.append(
+                cwl.CommandInputParameter(
+                    id=wdl_twelveth_input.name,
+                    type="int", default=wdl_twelveth_input.expr.literal.value
+                )
+            )
+    wdl_thirteenth_input = inputs[12]
+    cwl_inputs.append(
+                cwl.CommandInputParameter(
+                    id=wdl_thirteenth_input.name,
+                    type="string", default=wdl_thirteenth_input.expr.literal.value
+                )
+            )
+    
+    wdl_outputs = task.outputs
+    cwl_outputs = []
+    wdl_first_output = wdl_outputs[0]
+
+    cwl_outputs.append(
+    cwl.CommandOutputParameter(
+        id=wdl_first_output.name,
+        type="File",
+        outputBinding=cwl.CommandOutputBinding(glob="$(inputs.{outputpath})".format(outputpath=wdl_first_output.expr.expr.name)),
+        )
+    )
+
+
+
+    # Resulting cwl output
+    base_command = ["bash", "example.sh"]
+
+    cat_tool = cwl.CommandLineTool(
+    id=task.name,
+    inputs=cwl_inputs,
+    requirements=None,
+    outputs=cwl_outputs,
+    cwlVersion="v1.2",
+    baseCommand=base_command,
+    )
+
+    yaml = YAML()
+    yaml.default_flow_style = False
+    yaml.indent = 4
+    yaml.block_seq_indent = 2
+    result_stream = StringIO()
+    cwl_result = cat_tool.save()
+    scalarstring.walk_tree(cwl_result)
+    yaml.dump(cwl_result, result_stream)
+    yaml.dump(cwl_result, sys.stdout)
+
+    result_stream.getvalue()
+
+    # write to a file in oop_cwl_files
+    with open("wdl2cwl/tests/oop_cwl_files/bowtie_1.cwl", "w") as result:
+        result.write(result_stream.getvalue())
+
+    # try:
+    #     converted = Converter.load_wdl_tree("wdl2cwl/tests/wdl_files/bowtie_1.wdl")
+    #     # converted = Converter.load_wdl_tree(args.workflow)
+    # except WDL.Error.SyntaxError as err:
+    #     print(err)
+    # except WDL.Error.ValidationError as err:
+    #     print(err)
+    # except WDL.Error.MultipleValidationErrors as err:
+    #     for error in err.exceptions:
+    #         print(error)

--- a/wdl2cwl/main_oop.py
+++ b/wdl2cwl/main_oop.py
@@ -1,3 +1,4 @@
+"""Main entrypoint for WDL2CWL."""
 import os
 from typing import List, Union, Optional, Callable
 import WDL  # type: ignore[import]
@@ -141,7 +142,7 @@ from ruamel.yaml.main import YAML
 #         #     print(placeholder)
 #         pass
 def convert(path: str) -> str:
-    """convert just the bowtie_1 file."""
+    """Convert just the bowtie_1 file."""
     wdl_path = path
     doc_tree = WDL.load(wdl_path)
     task = doc_tree.tasks[0]
@@ -556,7 +557,7 @@ def convert(path: str) -> str:
 
 
 def main() -> None:
-    """The main entry point."""
+    """Main entry point."""
     # Command-line parsing.
     parser = argparse.ArgumentParser()
     parser.add_argument("workflow", help="Path to WDL workflow")

--- a/wdl2cwl/tests/oop_cwl_files/bowtie_1.cwl
+++ b/wdl2cwl/tests/oop_cwl_files/bowtie_1.cwl
@@ -6,7 +6,7 @@ inputs:
       - items: File
         type: array
   - id: outputPath
-    default: mapped.bam 
+    default: mapped.bam
     type: string
   - id: indexFiles
     type:
@@ -51,6 +51,9 @@ outputs:
     type: File
     outputBinding:
         glob: $(inputs.outputPath)
+requirements:
+  - class: DockerRequirement
+    dockerPull: quay.io/biocontainers/mulled-v2-bfe71839265127576d3cd749c056e7b168308d56:1d8bec77b352cdcf3e9ff3d20af238b33ed96eae-0
 cwlVersion: v1.2
 baseCommand:
   - bash

--- a/wdl2cwl/tests/oop_cwl_files/bowtie_1.cwl
+++ b/wdl2cwl/tests/oop_cwl_files/bowtie_1.cwl
@@ -60,7 +60,7 @@ requirements:
         entry: |4
 
             set -e -o pipefail
-            mkdir -p "$(dirname $(inputs.outputPath ))"
+            mkdir -p "\$(dirname $(inputs.outputPath ))"
                     bowtie \
                     -q \
                     --sam \

--- a/wdl2cwl/tests/oop_cwl_files/bowtie_1.cwl
+++ b/wdl2cwl/tests/oop_cwl_files/bowtie_1.cwl
@@ -57,21 +57,33 @@ requirements:
   - class: InitialWorkDirRequirement
     listing:
       - entryname: example.sh
-        entry: |4-
+        entry: |4
 
             set -e -o pipefail
-            mkdir -p "$(dirname $(inputs.outputPath))"
+            mkdir -p "$(dirname $(inputs.outputPath ))"
                     bowtie \
                     -q \
                     --sam \
-            $(inputs.seedmms === null ? "" : '--seedmms ' inputs.seedmms\
-            $(inputs.seedlen === null ? "" : '--seedlen ' inputs.seedlen\
-            $(inputs.k === null ? "" : '-k ' inputs.k\
-            $(inputs.best ? '--best' : '')\
-            $(inputs.strata ? '--strata' : '')\
-            $(inputs.allowContain ? '--allow-contain' : '')\
-            $(inputs.threads === null ? "" : '--threads ' inputs.threads\
-            $(inputs.samRG === null ? "" : '--sam-RG '' inputs.samRG
+            $(inputs.seedmms === null ? "" : "--seedmms " inputs.seedmms )\
+            $(inputs.seedlen === null ? "" : "--seedlen " inputs.seedlen )\
+            $(inputs.k === null ? "" : "-k " inputs.k )\
+            $(inputs.best ? "--best" : ""))\
+            $(inputs.strata ? "--strata" : ""))\
+            $(inputs.allowContain ? "--allow-contain" : ""))\
+            $(inputs.threads === null ? "" : "--threads " inputs.threads )\
+            $(inputs.samRG === null ? "" : "--sam-RG '" inputs.samRG )$(inputs.samRG ? "" : "'")\
+            $(inputs.indexFiles[0].replace( "(\.rev)?\.[0-9]\.ebwt$", "") )\
+            $(inputs.readsUpstream.map(function(el) {return el.path}).join(","))\
+                   | picard -Xmx$(inputs.picardXmx) SortSam \
+                   INPUT=/dev/stdin \
+                   OUTPUT=$(inputs.outputPath) \
+                   SORT_ORDER=coordinate \
+                   CREATE_INDEX=true
+  - class: InlineJavascriptRequirement
+  - class: NetworkAccess
+    networkAccess: true
+  - class: ResourceRequirement
+    ramMin: $(inputs.threads)
 cwlVersion: v1.2
 baseCommand:
   - bash

--- a/wdl2cwl/tests/oop_cwl_files/bowtie_1.cwl
+++ b/wdl2cwl/tests/oop_cwl_files/bowtie_1.cwl
@@ -54,6 +54,24 @@ outputs:
 requirements:
   - class: DockerRequirement
     dockerPull: quay.io/biocontainers/mulled-v2-bfe71839265127576d3cd749c056e7b168308d56:1d8bec77b352cdcf3e9ff3d20af238b33ed96eae-0
+  - class: InitialWorkDirRequirement
+    listing:
+      - entryname: example.sh
+        entry: |4-
+
+            set -e -o pipefail
+            mkdir -p "$(dirname $(inputs.outputPath))"
+                    bowtie \
+                    -q \
+                    --sam \
+            $(inputs.seedmms === null ? "" : '--seedmms ' inputs.seedmms\
+            $(inputs.seedlen === null ? "" : '--seedlen ' inputs.seedlen\
+            $(inputs.k === null ? "" : '-k ' inputs.k\
+            $(inputs.best ? '--best' : '')\
+            $(inputs.strata ? '--strata' : '')\
+            $(inputs.allowContain ? '--allow-contain' : '')\
+            $(inputs.threads === null ? "" : '--threads ' inputs.threads\
+            $(inputs.samRG === null ? "" : '--sam-RG '' inputs.samRG
 cwlVersion: v1.2
 baseCommand:
   - bash

--- a/wdl2cwl/tests/oop_cwl_files/bowtie_1.cwl
+++ b/wdl2cwl/tests/oop_cwl_files/bowtie_1.cwl
@@ -1,0 +1,57 @@
+class: CommandLineTool
+id: Bowtie
+inputs:
+  - id: readsUpstream
+    type:
+      - items: File
+        type: array
+  - id: outputPath
+    default: mapped.bam 
+    type: string
+  - id: indexFiles
+    type:
+      - items: File
+        type: array
+  - id: best
+    default: false
+    type: boolean
+  - id: strata
+    default: false
+    type: boolean
+  - id: allowContain
+    default: false
+    type: boolean
+  - id: seedmms
+    type:
+      - int
+      - 'null'
+  - id: seedlen
+    type:
+      - int
+      - 'null'
+  - id: k
+    type:
+      - int
+      - 'null'
+  - id: samRG
+    type:
+      - string
+      - 'null'
+  - id: picardXmx
+    default: 4G
+    type: string
+  - id: threads
+    default: 1
+    type: int
+  - id: dockerImage
+    default: quay.io/biocontainers/mulled-v2-bfe71839265127576d3cd749c056e7b168308d56:1d8bec77b352cdcf3e9ff3d20af238b33ed96eae-0
+    type: string
+outputs:
+  - id: outputBam
+    type: File
+    outputBinding:
+        glob: $(inputs.outputPath)
+cwlVersion: v1.2
+baseCommand:
+  - bash
+  - example.sh

--- a/wdl2cwl/tests/test_miniwdl.py
+++ b/wdl2cwl/tests/test_miniwdl.py
@@ -7,6 +7,7 @@ from .. import main_oop as wdl
 
 
 def get_file(path: str) -> str:
+    """Get file."""
     return os.path.join(os.path.dirname(__file__), path)
 
 

--- a/wdl2cwl/tests/test_miniwdl.py
+++ b/wdl2cwl/tests/test_miniwdl.py
@@ -1,3 +1,4 @@
+''' Tests for miniwdl '''
 import os.path
 import pytest
 import pathlib

--- a/wdl2cwl/tests/test_miniwdl.py
+++ b/wdl2cwl/tests/test_miniwdl.py
@@ -1,0 +1,29 @@
+import os.path
+import pytest
+import pathlib
+import filecmp
+
+from .. import main_oop as wdl
+
+
+def get_file(path: str) -> str:
+    return os.path.join(os.path.dirname(__file__), path)
+
+
+@pytest.mark.parametrize(
+    "wdl_path,cwl_path",
+    [
+        ("wdl_files/bowtie_1.wdl", "oop_cwl_files/bowtie_1.cwl"),
+    ],
+)
+class TestParameterized:
+    """Contains the test functions for WDL to CWL conversion."""
+
+    def test_wdls(self, wdl_path: str, cwl_path: str) -> None:
+        """Test WDL to CWL conversion."""
+        convertedStr = wdl.convert(get_file(wdl_path))
+        testStr = ""
+        with open(get_file(cwl_path)) as file:
+            testStr = file.read()
+
+        assert convertedStr == testStr

--- a/wdl2cwl/tests/test_miniwdl.py
+++ b/wdl2cwl/tests/test_miniwdl.py
@@ -1,4 +1,4 @@
-''' Tests for miniwdl '''
+"""Tests for miniwdl."""
 import os.path
 import pytest
 import pathlib


### PR DESCRIPTION
Draft to use miniwdl to implement an object oriented version of the wdl2cwl converter.

1. Convert a single wdl file to cwl by hand without loops, if conditions or classes.
    - Handled inputs
    - Handled outputs
    - Handled command section
    - Handled runtime section
  