### PR TITLE
handle all validateOptimus files 

### DIFF
--- a/wdl2cwl/main_oop.py
+++ b/wdl2cwl/main_oop.py
@@ -2,7 +2,6 @@
 import os
 import re
 from typing import List, Union, Optional, Callable, cast, Any, Set
-from typing_extensions import runtime
 import WDL
 import cwl_utils.parser.cwl_v1_2 as cwl
 import regex  # type: ignore

--- a/wdl2cwl/tests/oop_cwl_files/bcftools_annotate.cwl
+++ b/wdl2cwl/tests/oop_cwl_files/bcftools_annotate.cwl
@@ -152,6 +152,7 @@ requirements:
         else if(unit==="TB" || unit==="T") memory = (value*(1000*1000*1000*1000))/(1024*1024);
         return parseInt(memory);
         }
+    outdirMin: 1024
 cwlVersion: v1.2
 baseCommand:
   - bash

--- a/wdl2cwl/tests/oop_cwl_files/bcftools_stats.cwl
+++ b/wdl2cwl/tests/oop_cwl_files/bcftools_stats.cwl
@@ -167,6 +167,7 @@ requirements:
         else if(unit==="TB" || unit==="T") memory = (value*(1000*1000*1000*1000))/(1024*1024);
         return parseInt(memory);
         }
+    outdirMin: 1024
 cwlVersion: v1.2
 baseCommand:
   - bash

--- a/wdl2cwl/tests/oop_cwl_files/bowtie_1.cwl
+++ b/wdl2cwl/tests/oop_cwl_files/bowtie_1.cwl
@@ -84,6 +84,7 @@ requirements:
     networkAccess: true
   - class: ResourceRequirement
     coresMin: $(inputs.threads)
+    outdirMin: 1024
 cwlVersion: v1.2
 baseCommand:
   - bash

--- a/wdl2cwl/tests/oop_cwl_files/validateOptimus_1.cwl
+++ b/wdl2cwl/tests/oop_cwl_files/validateOptimus_1.cwl
@@ -42,6 +42,7 @@ requirements:
   - class: ResourceRequirement
     coresMin: 1
     ramMin: 3576.2786865234375
+    outdirMin: 1024
 cwlVersion: v1.2
 baseCommand:
   - bash

--- a/wdl2cwl/tests/oop_cwl_files/validateOptimus_2.cwl
+++ b/wdl2cwl/tests/oop_cwl_files/validateOptimus_2.cwl
@@ -42,6 +42,7 @@ requirements:
   - class: ResourceRequirement
     coresMin: 1
     ramMin: 3576.2786865234375
+    outdirMin: 1024
 cwlVersion: v1.2
 baseCommand:
   - bash

--- a/wdl2cwl/tests/oop_cwl_files/validateOptimus_3.cwl
+++ b/wdl2cwl/tests/oop_cwl_files/validateOptimus_3.cwl
@@ -1,0 +1,71 @@
+class: CommandLineTool
+id: ValidateMatrix
+inputs:
+  - id: matrix
+    type: File
+  - id: matrix_row_index
+    type: File
+  - id: matrix_col_index
+    type: File
+  - id: reference_matrix
+    type: File
+outputs:
+  - id: result
+    type: string
+    outputBinding:
+        loadContents: true
+        glob: result.txt
+        outputEval: $(self[0].contents.replace(/[\r\n]+$/, ''))
+  - id: new_reference_matrix
+    type: File
+    outputBinding:
+        glob: newReferenceMatrix.rds
+  - id: reads_per_cell_histogram
+    type: File
+    outputBinding:
+        glob: reads_per_cell_histogram.png
+  - id: reads_per_gene_histogram
+    type: File
+    outputBinding:
+        glob: reads_per_gene_histogram.png
+  - id: number_of_genes_per_cell
+    type: File
+    outputBinding:
+        glob: number_of_genes_per_cell.png
+requirements:
+  - class: DockerRequirement
+    dockerPull: quay.io/humancellatlas/optimus-matrix-test:0.0.7
+  - class: InitialWorkDirRequirement
+    listing:
+      - entryname: example.sh
+        entry: |4+
+
+             cacheInvalidationRandomString=4
+
+            ## Convert matrix to format that can be read by R
+            npz2rds.sh -c $(inputs.matrix_col_index.path) -r $(inputs.matrix_row_index.path) \
+            -d $(inputs.matrix.path) -o matrix.rds
+
+            cp $(inputs.reference_matrix.path) referenceMatrix.rds
+
+            ## Run tests
+            Rscript /root/tools/checkMatrix.R
+            checkMatrixResult=$?
+
+            if [ $checkMatrixResult == 0 ]; then
+                printf PASS > result.txt
+            else
+                printf FAIL > result.txt
+            fi
+
+  - class: InlineJavascriptRequirement
+  - class: NetworkAccess
+    networkAccess: true
+  - class: ResourceRequirement
+    coresMin: 1
+    ramMin: 15258.7890625
+    outdirMin: 1024
+cwlVersion: v1.2
+baseCommand:
+  - bash
+  - example.sh

--- a/wdl2cwl/tests/oop_cwl_files/validateOptimus_4.cwl
+++ b/wdl2cwl/tests/oop_cwl_files/validateOptimus_4.cwl
@@ -1,0 +1,66 @@
+class: CommandLineTool
+id: ValidateMetrics
+inputs:
+  - id: cell_metrics
+    type: File
+  - id: gene_metrics
+    type: File
+  - id: expected_cell_metric_hash
+    type: string
+  - id: expected_gene_metric_hash
+    type: string
+outputs:
+  - id: result
+    type: string
+    outputBinding:
+        loadContents: true
+        glob: result.txt
+        outputEval: $(self[0].contents.replace(/[\r\n]+$/, ''))
+requirements:
+  - class: DockerRequirement
+    dockerPull: ubuntu:18.04
+  - class: InitialWorkDirRequirement
+    listing:
+      - entryname: example.sh
+        entry: |4
+
+            set -eo pipefail
+
+            cacheInvalidationRandomString=4
+
+            # check matrix row and column indexes files hash
+            gene_metric_hash=\$(zcat "$(inputs.gene_metrics.path)" | md5sum | awk '{print $1}')
+            cell_metric_hash=\$(zcat "$(inputs.cell_metrics.path)" | md5sum | awk '{print $1}')
+
+            fail=false
+
+            if [ "$gene_metric_hash" == "$(inputs.expected_gene_metric_hash)" ]; then
+                echo Computed and expected gene metrics match \( "$gene_metric_hash" \)
+            else
+                echo Computed \( "$gene_metric_hash" \) and expected \( "$(inputs.expected_gene_metric_hash)" \) gene checksums do not match
+                fail=true
+            fi
+
+            if [ "$cell_metric_hash" == "$(inputs.expected_cell_metric_hash)" ]; then
+                echo Computed and expected cell metrics match \( "$cell_metric_hash" \)
+            else
+                echo Computed \( "$cell_metric_hash" \) and expected \( "$(inputs.expected_cell_metric_hash)" \) cell metrics hashes do not match
+                fail=true
+            fi
+
+            if [ $fail == "true" ]; then
+                printf FAIL > result.txt
+            else
+                printf PASS > result.txt
+            fi
+  - class: InlineJavascriptRequirement
+  - class: NetworkAccess
+    networkAccess: true
+  - class: ResourceRequirement
+    coresMin: 1
+    ramMin: 953.67431640625
+    outdirMin: 1024
+cwlVersion: v1.2
+baseCommand:
+  - bash
+  - example.sh

--- a/wdl2cwl/tests/oop_cwl_files/validateOptimus_5.cwl
+++ b/wdl2cwl/tests/oop_cwl_files/validateOptimus_5.cwl
@@ -1,0 +1,65 @@
+class: CommandLineTool
+id: GenerateReport
+inputs:
+  - id: bam_validation_result
+    type: string
+  - id: metric_and_index_validation_result
+    type: string
+  - id: matrix_validation_result
+    type: string
+  - id: loom_validation_result
+    type: string
+outputs: []
+requirements:
+  - class: DockerRequirement
+    dockerPull: ubuntu:18.04
+  - class: InitialWorkDirRequirement
+    listing:
+      - entryname: example.sh
+        entry: |4+
+
+
+            set -eo pipefail
+
+            cacheInvalidationRandomString=4
+
+            # test each output for equality, echoing any failure states to stdout
+            fail=false
+
+            echo Bam Validation: $(inputs.bam_validation_result)
+            if [ "$(inputs.bam_validation_result)" == "FAIL" ]; then
+                fail=true
+            fi
+
+            echo Metrics Validation: $(inputs.metric_and_index_validation_result)
+            if [ $(inputs.metric_and_index_validation_result) == "FAIL" ]; then
+                echo --- Ignoring failed metric and index test ---
+                # Do not fail tests for this
+                # fail=true
+            fi
+
+            echo Matrix Validation: $(inputs.matrix_validation_result)
+            if [ "$(inputs.matrix_validation_result)" == "FAIL" ]; then
+                fail=true
+            fi
+
+            echo Loom Validation: $(inputs.loom_validation_result)
+            if [ "$(inputs.loom_validation_result)" == "FAIL" ]; then
+                echo --- Ignoring failed loom test ---
+                # Do not fail tests for this
+                # fail=true
+            fi
+
+            if [ "$fail" == "true" ]; then exit 1; fi
+
+  - class: InlineJavascriptRequirement
+  - class: NetworkAccess
+    networkAccess: true
+  - class: ResourceRequirement
+    coresMin: 1
+    ramMin: 953.67431640625
+    outdirMin: 1024
+cwlVersion: v1.2
+baseCommand:
+  - bash
+  - example.sh

--- a/wdl2cwl/tests/test_miniwdl.py
+++ b/wdl2cwl/tests/test_miniwdl.py
@@ -20,6 +20,9 @@ def get_file(path: str) -> str:
         ("wdl_files/bcftools_annotate.wdl", "oop_cwl_files/bcftools_annotate.cwl"),
         ("wdl_files/validateOptimus_1.wdl", "oop_cwl_files/validateOptimus_1.cwl"),
         ("wdl_files/validateOptimus_2.wdl", "oop_cwl_files/validateOptimus_2.cwl"),
+        ("wdl_files/validateOptimus_3.wdl", "oop_cwl_files/validateOptimus_3.cwl"),
+        ("wdl_files/validateOptimus_4.wdl", "oop_cwl_files/validateOptimus_4.cwl"),
+        ("wdl_files/validateOptimus_5.wdl", "oop_cwl_files/validateOptimus_5.cwl"),
     ],
 )
 class TestParameterized:


### PR DESCRIPTION
Translate all validateOptimus files and return a default of 1GB (1024) for outdirMin in all cwl files (future implementations will handle more derived values)
Also. Return appropriate strings for glob in cwl output derived from wdl outputs with string literals.