### PR TITLE
Use a convert function like the former main file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,7 @@ env/
 wdl2cwl.egg-info/
 coverage.xml
 .coverage
+build/
+dist/
+pydocstyle_report.txt
+

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,3 +12,7 @@ include_trailing_comma = True
 force_grid_wrap = 0
 use_parentheses = True
 line_length = 88
+
+[options.entry_points]
+console_scripts=
+    wdl2cwl = wdl2cwl.main_oop:main

--- a/wdl2cwl/main_oop.py
+++ b/wdl2cwl/main_oop.py
@@ -1,12 +1,11 @@
 """Main entrypoint for WDL2CWL."""
 import os
 import re
-from typing import List, Union, Optional, Callable, cast, Any, Set
+from typing import List, Union, Optional, Any, Set
 import WDL
 import cwl_utils.parser.cwl_v1_2 as cwl
 import regex  # type: ignore
 
-from io import StringIO
 import textwrap
 import sys
 import argparse
@@ -24,12 +23,12 @@ valid_js_identifier = regex.compile(
 )
 
 
-def convert(doc: str) -> str:
-    """Load WDL file, instantiate Converter class and loads the WDL document tree."""
+def convert(doc: str) -> cwl.CommandLineTool:
+    """Convert a WDL workflow, reading the file, into a CWL workflow Python object."""
     wdl_path = os.path.relpath(doc)
     doc_tree = WDL.load(wdl_path)
 
-    parser = Converter()  # type: ignore
+    parser = Converter()
 
     if doc_tree.workflow:
         return parser.load_wdl_objects(doc_tree.workflow)
@@ -44,12 +43,14 @@ def convert(doc: str) -> str:
 class Converter:
     """Object that handles WDL Workflows and task conversion to CWL."""
 
-    def __init__(self):  # type: ignore
+    def __init__(self) -> None:
         """Initialize the sets used by the object and prevent inconsistent behaviours."""
         self.non_static_values: Set[str] = set()
         self.optional_cwl_null: Set[str] = set()
 
-    def load_wdl_objects(self, obj: Union[WDL.Tree.Task, WDL.Tree.Workflow]) -> str:
+    def load_wdl_objects(
+        self, obj: Union[WDL.Tree.Task, WDL.Tree.Workflow]
+    ) -> cwl.CommandLineTool:
         """Load a WDL SourceNode obj and returns either a Task or a Workflow."""
         if isinstance(obj, WDL.Tree.Task):
             return self.load_wdl_task(obj)
@@ -62,7 +63,7 @@ class Converter:
     #     print(f"Workflow {obj.name} loaded")
     #     pass
 
-    def load_wdl_task(self, obj: WDL.Tree.Task) -> str:
+    def load_wdl_task(self, obj: WDL.Tree.Task) -> cwl.CommandLineTool:
         """Load task and convert to CWL."""
         cwl_inputs = self.get_cwl_inputs(obj.inputs)
         cwl_outputs = self.get_cwl_outputs(obj.outputs)
@@ -114,7 +115,7 @@ class Converter:
                 )
             )
 
-        cat_tool = cwl.CommandLineTool(
+        return cwl.CommandLineTool(
             id=obj.name,
             inputs=cwl_inputs,
             requirements=requirements,
@@ -122,18 +123,6 @@ class Converter:
             cwlVersion="v1.2",
             baseCommand=base_command,
         )
-
-        yaml = YAML()
-        yaml.default_flow_style = False
-        yaml.indent = 4
-        yaml.block_seq_indent = 2
-        result_stream = StringIO()
-        cwl_result = cat_tool.save()
-        scalarstring.walk_tree(cwl_result)
-        yaml.dump(cwl_result, result_stream)
-        yaml.dump(cwl_result, sys.stdout)
-
-        return result_stream.getvalue()
 
     def get_time_minutes_requirement(
         self, time_minutes: WDL.Expr.Get
@@ -783,22 +772,36 @@ class Converter:
         return outputs
 
 
-def main() -> None:
+def main(args: Union[List[str], None] = None) -> None:
     """Entry point."""
     # Command-line parsing.
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(
+        description="Converts WDL workflows into CWL workflows. Outputs "
+        "to <stdout> by default."
+    )
     parser.add_argument("workflow", help="Path to WDL workflow")
-    parser.add_argument("-o", "--output", help="Name of resultant CWL file")
-    args = parser.parse_args()
+    parser.add_argument("-o", "--output", help="Name of output CWL file")
+    parsed_args = parser.parse_args(args)
 
-    # write to a file in oop_cwl_files
-    if args.output:
-        with open(args.output, "w") as result:
-            result.write(convert(args.workflow))
+    result = convert(parsed_args.workflow)
+    cwl_result = result.save()
+
+    # Serialize result in YAML to either <stdout> or specified output file.
+    yaml = YAML()
+    yaml.default_flow_style = False
+    yaml.indent = 4
+    yaml.block_seq_indent = 2
+    scalarstring.walk_tree(cwl_result)
+
+    if parsed_args.output is None:
+        yaml.dump(cwl_result, sys.stdout)
+    else:
+        with open(parsed_args.output, "w") as f:
+            yaml.dump(cwl_result, f)
 
     # Converter.load_wdl_tree("wdl2cwl/tests/wdl_files/bowtie_1.wdl")
 
 
 if __name__ == "__main__":
 
-    main()
+    main(sys.argv[1:])  # pragma: no cover

--- a/wdl2cwl/tests/test_miniwdl.py
+++ b/wdl2cwl/tests/test_miniwdl.py
@@ -1,10 +1,8 @@
 """Tests for miniwdl."""
 import os.path
 import pytest
-import pathlib
-import filecmp
 
-from .. import main_oop as wdl
+from ..main_oop import convert
 
 
 def get_file(path: str) -> str:
@@ -54,7 +52,7 @@ class TestParameterized:
 
     def test_wdls(self, wdl_path: str, cwl_path: str) -> None:
         """Test WDL to CWL conversion."""
-        convertedStr = wdl.Converter.load_wdl_tree(get_file(wdl_path))
+        convertedStr = convert(get_file(wdl_path))
         testStr = ""
         with open(get_file(cwl_path)) as file:
             testStr = file.read()

--- a/wdl2cwl/tests/test_miniwdl.py
+++ b/wdl2cwl/tests/test_miniwdl.py
@@ -1,8 +1,10 @@
 """Tests for miniwdl."""
 import os.path
+from tempfile import NamedTemporaryFile
+from pathlib import Path
 import pytest
 
-from ..main_oop import convert
+from ..main_oop import main
 
 
 def get_file(path: str) -> str:
@@ -47,14 +49,19 @@ def get_file(path: str) -> str:
         ),
     ],
 )
-class TestParameterized:
-    """Contains the test functions for WDL to CWL conversion."""
+def test_wdls(wdl_path: str, cwl_path: str) -> None:
+    """Test WDL to CWL conversion."""
+    with open(get_file(cwl_path), encoding="utf-8") as file:
+        with NamedTemporaryFile(mode="w", encoding="utf-8") as output:
+            main(["-o", output.name, get_file(wdl_path)])
+            output.flush()
+            assert Path(output.name).read_text(encoding="utf-8") == file.read()
 
-    def test_wdls(self, wdl_path: str, cwl_path: str) -> None:
-        """Test WDL to CWL conversion."""
-        convertedStr = convert(get_file(wdl_path))
-        testStr = ""
-        with open(get_file(cwl_path)) as file:
-            testStr = file.read()
 
-        assert convertedStr == testStr
+def test_wdl_stdout(capsys) -> None:  # type: ignore
+    """Test WDL to CWL conversion using stdout."""
+    with open(get_file("oop_cwl_files/bowtie_1.cwl"), encoding="utf-8") as file:
+        main([get_file("wdl_files/bowtie_1.wdl")])
+        captured = capsys.readouterr()
+        assert captured.out == file.read()
+        assert captured.err == ""


### PR DESCRIPTION
It is strange to have to import a class to call a static method, which will then create an instance of the class and call a function.

This PR exports a `convert(str) -> str` function, which has the exact same signature from the existing `main.py`. The `convert` function will then create the object and call its function passing any parameters if necessary.

I think this will be simpler from a user POV.