### PR TITLE
Fix wdl2cwl command module location

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -15,4 +15,4 @@ line_length = 88
 
 [options.entry_points]
 console_scripts=
-    wdl2cwl = wdl2cwl.main_oop:main
+    wdl2cwl = wdl2cwl.main:main


### PR DESCRIPTION
Noticed it was broken when trying #141 

Later we might be able to add some functional tests that execute the script as well, to prevent another regression.