### PR TITLE
set root folder for WDL imports

### DIFF
--- a/wdl2cwl/main.py
+++ b/wdl2cwl/main.py
@@ -1,16 +1,15 @@
 """Main entrypoint for WDL2CWL."""
 import argparse
-import os
 import re
 import sys
 import textwrap
+from pathlib import Path
 from typing import (
     Any,
     Dict,
     Iterator,
     List,
     Optional,
-    Mapping,
     Sequence,
     Set,
     Tuple,
@@ -26,8 +25,8 @@ import WDL
 import WDL._parser  # delete when reloading bug is fixed upstream
 import WDL.CLI
 from ruamel.yaml import scalarstring
-from ruamel.yaml.main import YAML
 from ruamel.yaml.comments import CommentedMap
+from ruamel.yaml.main import YAML
 
 from wdl2cwl import _logger
 from wdl2cwl.errors import WDLSourceLine
@@ -53,9 +52,10 @@ class ConversionException(Exception):
 def convert(doc: str) -> Dict[str, Any]:
     """Convert a WDL workflow, reading the file, into a CWL workflow Python object."""
     WDL._parser._lark_comments_buffer.clear()
+    root_folder = str(Path(doc).parent)
     try:
         doc_tree = WDL.load(
-            doc, [], read_source=WDL.CLI.make_read_source(False), check_quant=True  # type: ignore[no-untyped-call]
+            doc, [root_folder], read_source=WDL.CLI.make_read_source(False), check_quant=True  # type: ignore[no-untyped-call]
         )
     except (
         WDL.Error.SyntaxError,


### PR DESCRIPTION
Needed for https://github.com/biowdl/germline-DNA/blob/4a4a8cf268badd08e075607d4bdd9c0d33812fa8/somatic.wdl from a checkout of that repo (doesn't work via raw GitHub URL due to git submodules)

```
[Errno 2] No such file or directory: 'tasks/gatk.wdl'
Traceback (most recent call last):
  File "/home/michael/wdl2cwl/env/lib/python3.9/site-packages/WDL/Tree.py", line 1538, in _load_async
    subdoc = await _load_async(
  File "/home/michael/wdl2cwl/env/lib/python3.9/site-packages/WDL/Tree.py", line 1518, in _load_async
    read_rslt = await read_source(uri, path, importer)
  File "/home/michael/wdl2cwl/env/lib/python3.9/site-packages/WDL/CLI.py", line 438, in read_source
    ans = await read_source_default(uri, path, importer)
  File "/home/michael/wdl2cwl/env/lib/python3.9/site-packages/WDL/__init__.py", line 126, in read_source_default
    return await Tree.read_source_default(uri, path, importer)
  File "/home/michael/wdl2cwl/env/lib/python3.9/site-packages/WDL/Tree.py", line 1499, in read_source_default
    abspath = await resolve_file_import(uri, path, importer)
  File "/home/michael/wdl2cwl/env/lib/python3.9/site-packages/WDL/Tree.py", line 1490, in resolve_file_import
    raise FileNotFoundError(errno.ENOENT, os.strerror(errno.ENOENT), uri)
FileNotFoundError: [Errno 2] No such file or directory: 'tasks/gatk.wdl'
```