### PR TITLE
upload to codecov using the token

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -57,6 +57,7 @@ jobs:
         uses: codecov/codecov-action@v1
         with:
           fail_ci_if_error: true
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   tox-style:
     name: CI linters via Tox


### PR DESCRIPTION
This should fix the timeouts caused by GitHub rate-limiting CodeCov.io

https://github.com/codecov/codecov-action/issues/598